### PR TITLE
Removed unneeded calls to [super loadView]

### DIFF
--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
@@ -83,8 +83,6 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 #pragma mark UIViewController
 
 - (void)loadView {
-    [super loadView];
-
     self.collectionView.backgroundColor = [UIColor whiteColor];
 
     [self.collectionView registerClass:[PFCollectionViewCell class]

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -100,8 +100,6 @@
 #pragma mark UIViewController
 
 - (void)loadView {
-    [super loadView];
-
     if (self.loadingViewEnabled) {
         self.loadingView = [[PFLoadingView alloc] initWithFrame:CGRectZero];
         [self.tableView addSubview:self.loadingView];


### PR DESCRIPTION
As it stated in the [docs](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/index.html#//apple_ref/occ/instm/UIViewController/loadView),
> Your custom implementation of this method should not call super. 