### PR TITLE
Implement infinite scrolling

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -119,9 +119,9 @@
 @property (nonatomic, assign, getter=isLoading) BOOL loading;
 
 /*!
- @abstract Whether the table should use built-in infinite scrolling feature.  Default - `NO`.
+ @abstract Whether the table should use built-in feature to automatically load next page. Default - `NO`.
  */
-@property (nonatomic, assign) BOOL infiniteScrolling;
+@property (nonatomic, assign) BOOL automaticallyLoadsNextPage;
 
 ///--------------------------------------
 /// @name Responding to Events

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -118,6 +118,11 @@
  */
 @property (nonatomic, assign, getter=isLoading) BOOL loading;
 
+/*!
+ @abstract Whether the table should use built-in infinite scrolling feature.  Default - `NO`.
+ */
+@property (nonatomic, assign) BOOL infiniteScrolling;
+
 ///--------------------------------------
 /// @name Responding to Events
 ///--------------------------------------

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -92,6 +92,7 @@
     _paginationEnabled = YES;
     _pullToRefreshEnabled = YES;
     _lastLoadCount = -1;
+    _infiniteScrolling = NO;
 
     _parseClassName = [otherClassName copy];
 }
@@ -250,6 +251,18 @@
     [self _loadImagesForOnscreenRows];
 }
 
+// loadNextPage if infiniteSrolling = YES
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if (self.infiniteScrolling) {
+        if (scrollView.contentSize.height - scrollView.contentOffset.y < (self.view.bounds.size.height)) {
+            if (![self isLoading]) {
+                [self loadNextPage];
+            }
+        }
+    }
+}
+
+
 #pragma mark -
 #pragma mark UITableViewDataSource
 
@@ -365,6 +378,9 @@
 
 // Whether we need to show the pagination cell
 - (BOOL)_shouldShowPaginationCell {
+    if (self.infiniteScrolling) {
+        return NO;
+    }
     return (self.paginationEnabled &&
             [self.objects count] != 0 &&
             (_lastLoadCount == -1 || _lastLoadCount >= (NSInteger)self.objectsPerPage));

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -92,7 +92,7 @@
     _paginationEnabled = YES;
     _pullToRefreshEnabled = YES;
     _lastLoadCount = -1;
-    _infiniteScrolling = NO;
+    _automaticallyLoadsNextPage = NO;
 
     _parseClassName = [otherClassName copy];
 }
@@ -253,9 +253,9 @@
 
 // loadNextPage if infiniteSrolling = YES
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    if (self.infiniteScrolling) {
-        if (scrollView.contentSize.height - scrollView.contentOffset.y < (self.view.bounds.size.height)) {
-            if (![self isLoading]) {
+    if (self.automaticallyLoadsNextPage) {
+        if (scrollView.contentSize.height - scrollView.contentOffset.y < CGRectGetMaxY(self.view.bounds)) {
+            if (!self.loading){
                 [self loadNextPage];
             }
         }
@@ -378,7 +378,7 @@
 
 // Whether we need to show the pagination cell
 - (BOOL)_shouldShowPaginationCell {
-    if (self.infiniteScrolling) {
+    if (self.automaticallyLoadsNextPage) {
         return NO;
     }
     return (self.paginationEnabled &&


### PR DESCRIPTION
Add infinite scrolling to PFQueryTableViewController so when user scrolls to bottom of the table it will automatically load the next page instead of showing the load more cell.  Default for this option is NO.  But feature is easily turned on with self.infiniteScrolling = YES;