### PR TITLE
Added IBInspectable support for PFQueryTableViewController, added Storyboard example.

### DIFF
--- a/ParseUI.xcodeproj/project.pbxproj
+++ b/ParseUI.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		81C599451A645A9100F574E8 /* PFActivityIndicatorCollectionReusableView.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C599431A645A9100F574E8 /* PFActivityIndicatorCollectionReusableView.h */; };
 		81C599461A645A9100F574E8 /* PFActivityIndicatorCollectionReusableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C599441A645A9100F574E8 /* PFActivityIndicatorCollectionReusableView.m */; };
 		81C599491A64636200F574E8 /* SectionedCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C599481A64636200F574E8 /* SectionedCollectionViewController.m */; };
+		81C8D9BA1A89085D007B8DCF /* SimpleQueryTableStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81C8D9B91A890857007B8DCF /* SimpleQueryTableStoryboard.storyboard */; };
+		81C8D9BD1A890BCA007B8DCF /* StoryboardTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C8D9BC1A890BCA007B8DCF /* StoryboardTableViewController.m */; };
 		81E9CCFF19F56D3100487B0F /* PFSignUpView.h in Headers */ = {isa = PBXBuildFile; fileRef = 81E9CCD319F56D3000487B0F /* PFSignUpView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81E9CD0019F56D3100487B0F /* PFSignUpView.m in Sources */ = {isa = PBXBuildFile; fileRef = 81E9CCD419F56D3000487B0F /* PFSignUpView.m */; };
 		81E9CD0119F56D3100487B0F /* PFSignUpViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81E9CCD519F56D3000487B0F /* PFSignUpViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -115,7 +117,7 @@
 		810D6C3219F7F38B005B3DB2 /* PFPurchaseTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPurchaseTableViewCell.h; sourceTree = "<group>"; };
 		810D6C3319F7F38B005B3DB2 /* PFPurchaseTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPurchaseTableViewCell.m; sourceTree = "<group>"; };
 		811B095A1A0843B9008B3393 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ParseUI/Resources/Info.plist; sourceTree = SOURCE_ROOT; };
-		812E5C001A7A8EB4000FBDE1 /* SimpleQueryCollectionStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SimpleQueryCollectionStoryboard.storyboard; sourceTree = "<group>"; };
+		812E5C001A7A8EB4000FBDE1 /* SimpleQueryCollectionStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SimpleQueryCollectionStoryboard.storyboard; path = ../../../Resources/SimpleQueryCollectionStoryboard.storyboard; sourceTree = "<group>"; };
 		812E5C021A7A8EFB000FBDE1 /* StoryboardCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StoryboardCollectionViewController.h; sourceTree = "<group>"; };
 		812E5C031A7A8EFB000FBDE1 /* StoryboardCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoryboardCollectionViewController.m; sourceTree = "<group>"; };
 		81472F671A1AB33800FD6EED /* ParseUIDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParseUIDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +164,9 @@
 		81C599441A645A9100F574E8 /* PFActivityIndicatorCollectionReusableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFActivityIndicatorCollectionReusableView.m; sourceTree = "<group>"; };
 		81C599471A64636200F574E8 /* SectionedCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SectionedCollectionViewController.h; sourceTree = "<group>"; };
 		81C599481A64636200F574E8 /* SectionedCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SectionedCollectionViewController.m; sourceTree = "<group>"; };
+		81C8D9B91A890857007B8DCF /* SimpleQueryTableStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SimpleQueryTableStoryboard.storyboard; path = ParseUIDemo/Resources/SimpleQueryTableStoryboard.storyboard; sourceTree = SOURCE_ROOT; };
+		81C8D9BB1A890BCA007B8DCF /* StoryboardTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StoryboardTableViewController.h; sourceTree = "<group>"; };
+		81C8D9BC1A890BCA007B8DCF /* StoryboardTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoryboardTableViewController.m; sourceTree = "<group>"; };
 		81E9CCD319F56D3000487B0F /* PFSignUpView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFSignUpView.h; sourceTree = "<group>"; };
 		81E9CCD419F56D3000487B0F /* PFSignUpView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFSignUpView.m; sourceTree = "<group>"; };
 		81E9CCD519F56D3000487B0F /* PFSignUpViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFSignUpViewController.h; sourceTree = "<group>"; };
@@ -384,6 +389,9 @@
 				81472F9E1A1AB37500FD6EED /* SubtitleImageTableViewController.m */,
 				81472F9F1A1AB37500FD6EED /* CustomProductTableViewController.h */,
 				81472FA01A1AB37500FD6EED /* CustomProductTableViewController.m */,
+				81C8D9BB1A890BCA007B8DCF /* StoryboardTableViewController.h */,
+				81C8D9BC1A890BCA007B8DCF /* StoryboardTableViewController.m */,
+				81C8D9B91A890857007B8DCF /* SimpleQueryTableStoryboard.storyboard */,
 			);
 			path = QueryTableViewController;
 			sourceTree = "<group>";
@@ -430,7 +438,6 @@
 				81472FA91A1AB37500FD6EED /* 0.png */,
 				81472FAA1A1AB37500FD6EED /* 1.png */,
 				81472FAB1A1AB37500FD6EED /* 2.png */,
-				812E5C001A7A8EB4000FBDE1 /* SimpleQueryCollectionStoryboard.storyboard */,
 			);
 			name = Resources;
 			path = ParseUIDemo/Resources;
@@ -467,6 +474,7 @@
 				819A4B391A6808EA00D01241 /* SubtitleImageCollectionViewController.m */,
 				812E5C021A7A8EFB000FBDE1 /* StoryboardCollectionViewController.h */,
 				812E5C031A7A8EFB000FBDE1 /* StoryboardCollectionViewController.m */,
+				812E5C001A7A8EB4000FBDE1 /* SimpleQueryCollectionStoryboard.storyboard */,
 			);
 			path = QueryCollectionViewController;
 			sourceTree = "<group>";
@@ -695,6 +703,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				81472FBC1A1AB37500FD6EED /* Images.xcassets in Resources */,
+				81C8D9BA1A89085D007B8DCF /* SimpleQueryTableStoryboard.storyboard in Resources */,
 				81472FBE1A1AB37500FD6EED /* 0.png in Resources */,
 				81472FBF1A1AB37500FD6EED /* 1.png in Resources */,
 				81472FC01A1AB37500FD6EED /* 2.png in Resources */,
@@ -767,6 +776,7 @@
 				812E5C041A7A8EFB000FBDE1 /* StoryboardCollectionViewController.m in Sources */,
 				81472FB51A1AB37500FD6EED /* SimpleTableViewController.m in Sources */,
 				81472FB61A1AB37500FD6EED /* PaginatedTableViewController.m in Sources */,
+				81C8D9BD1A890BCA007B8DCF /* StoryboardTableViewController.m in Sources */,
 				81472FB71A1AB37500FD6EED /* SectionedTableViewController.m in Sources */,
 				81472FB11A1AB37500FD6EED /* AppDelegate.m in Sources */,
 				81472FB21A1AB37500FD6EED /* PFUIDemoViewController.m in Sources */,

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -70,48 +70,48 @@
 /*!
  @abstract The class name of the <PFObject> this table will use as a datasource.
  */
-@property (nonatomic, copy) NSString *parseClassName;
+@property (nonatomic, copy) IBInspectable NSString *parseClassName;
 
 /*!
  @abstract The key to use to display for the cell text label.
 
  @discussion This won't apply if you override <tableView:cellForRowAtIndexPath:object:>
  */
-@property (nonatomic, copy) NSString *textKey;
+@property (nonatomic, copy) IBInspectable NSString *textKey;
 
 /*!
  @abstract The key to use to display for the cell image view.
 
  @discussion This won't apply if you override <tableView:cellForRowAtIndexPath:object:>
  */
-@property (nonatomic, copy) NSString *imageKey;
+@property (nonatomic, copy) IBInspectable NSString *imageKey;
 
 /*!
  @abstract The image to use as a placeholder for the cell images.
 
  @discussion This won't apply if you override <tableView:cellForRowAtIndexPath:object:>
  */
-@property (nonatomic, strong) UIImage *placeholderImage;
+@property (nonatomic, strong) IBInspectable UIImage *placeholderImage;
 
 /*!
  @abstract Whether the table should use the default loading view. Default - `YES`.
  */
-@property (nonatomic, assign) BOOL loadingViewEnabled;
+@property (nonatomic, assign) IBInspectable BOOL loadingViewEnabled;
 
 /*!
  @abstract Whether the table should use the built-in pull-to-refresh feature. Defualt - `YES`.
  */
-@property (nonatomic, assign) BOOL pullToRefreshEnabled;
+@property (nonatomic, assign) IBInspectable BOOL pullToRefreshEnabled;
 
 /*!
  @abstract Whether the table should use the built-in pagination feature. Default - `YES`.
  */
-@property (nonatomic, assign) BOOL paginationEnabled;
+@property (nonatomic, assign) IBInspectable BOOL paginationEnabled;
 
 /*!
  @abstract The number of objects to show per page. Default - `25`.
  */
-@property (nonatomic, assign) NSUInteger objectsPerPage;
+@property (nonatomic, assign) IBInspectable NSUInteger objectsPerPage;
 
 /*!
  @abstract Whether the table is actively loading new data from the server.

--- a/ParseUIDemo/Classes/CustomViewControllers/QueryTableViewController/StoryboardTableViewController.h
+++ b/ParseUIDemo/Classes/CustomViewControllers/QueryTableViewController/StoryboardTableViewController.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2014, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ *  copy, modify, and distribute this software in source code or binary form for use
+ *  in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#import <ParseUI/ParseUI.h>
+
+@interface StoryboardTableViewController : PFQueryTableViewController
+
+@end

--- a/ParseUIDemo/Classes/CustomViewControllers/QueryTableViewController/StoryboardTableViewController.m
+++ b/ParseUIDemo/Classes/CustomViewControllers/QueryTableViewController/StoryboardTableViewController.m
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2014, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ *  copy, modify, and distribute this software in source code or binary form for use
+ *  in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#import "StoryboardTableViewController.h"
+
+#import <Parse/PFObject.h>
+#import <Parse/PFQuery.h>
+
+#import <ParseUI/PFTableViewCell.h>
+
+@implementation StoryboardTableViewController
+
+#pragma mark -
+#pragma mark Data
+
+- (PFQuery *)queryForTable {
+    PFQuery *query = [super queryForTable];
+    [query orderByAscending:@"priority"];
+    return query;
+}
+
+#pragma mark -
+#pragma mark TableView
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath
+                        object:(PFObject *)object {
+    static NSString *cellIdentifier = @"cell";
+
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:cellIdentifier];
+    }
+
+    cell.textLabel.text = object[@"title"];
+    cell.detailTextLabel.text = [NSString stringWithFormat:@"Priority: %@", object[@"priority"]];
+
+    return cell;
+}
+
+@end

--- a/ParseUIDemo/Classes/PFUIDemoViewController.m
+++ b/ParseUIDemo/Classes/PFUIDemoViewController.m
@@ -33,6 +33,7 @@
 #import "SimpleCollectionViewController.h"
 #import "SimpleTableViewController.h"
 #import "StoryboardCollectionViewController.h"
+#import "StoryboardTableViewController.h"
 #import "SubtitleImageCollectionViewController.h"
 #import "SubtitleImageTableViewController.h"
 
@@ -40,6 +41,7 @@ typedef NS_ENUM(uint8_t, PFUIDemoType) {
     PFUIDemoTypeSimpleTable,
     PFUIDemoTypePaginatedTable,
     PFUIDemoTypeSectionedTable,
+    PFUIDemoTypeStoryboardTable,
     PFUIDemoTypeSimpleCollection,
     PFUIDemoTypePaginatedCollection,
     PFUIDemoTypeSectionedCollection,
@@ -87,6 +89,7 @@ typedef NS_ENUM(uint8_t, PFUIDemoType) {
         _descriptions = @[ @"Simple Table",
                            @"Paginated Table",
                            @"Sectioned Table",
+                           @"Simple Storyboard Table",
                            @"Simple Collection",
                            @"Paginated Collection",
                            @"Sectioned Collection",
@@ -161,6 +164,13 @@ typedef NS_ENUM(uint8_t, PFUIDemoType) {
             [self.navigationController pushViewController:controller animated:YES];
             break;
         }
+        case PFUIDemoTypeStoryboardTable: {
+            UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"SimpleQueryTableStoryboard" bundle:NULL];
+            StoryboardTableViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"StoryboardTableViewController"];
+            [self.navigationController pushViewController:controller animated:YES];
+            break;
+        }
+            break;
         case PFUIDemoTypeSimpleCollection: {
             SimpleCollectionViewController *controller = [[SimpleCollectionViewController alloc] initWithClassName:@"Todo"];
             [self.navigationController pushViewController:controller animated:YES];

--- a/ParseUIDemo/Resources/SimpleQueryTableStoryboard.storyboard
+++ b/ParseUIDemo/Resources/SimpleQueryTableStoryboard.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14D72i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
+    </dependencies>
+    <scenes>
+        <!--Storyboard Table-->
+        <scene sceneID="ta4-4V-fYS">
+            <objects>
+                <tableViewController storyboardIdentifier="StoryboardTableViewController" title="Storyboard Table" id="YGF-na-w3S" customClass="StoryboardTableViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="YvM-67-vGs">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="acj-m0-sNf">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="acj-m0-sNf" id="obM-Tq-NYq">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="YGF-na-w3S" id="1F6-RA-bj5"/>
+                            <outlet property="delegate" destination="YGF-na-w3S" id="BKH-wT-3qk"/>
+                        </connections>
+                    </tableView>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="parseClassName" value="Todo"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="paginationEnabled" value="NO"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="pullToRefreshEnabled" value="YES"/>
+                    </userDefinedRuntimeAttributes>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZNf-CW-x75" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1370" y="558"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
`IBInspectable` allows editing these properties inline inside Interface Builder / Storyboard.
This should simplify setting up a PFQueryTableViewController when using Storyboards or Interface Builder.

cc @hallucinogen, @grantland, @stanley-parse 