### PR TITLE
Added IBInspectable support for PFQueryCollectionViewController, updated example.

### DIFF
--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.h
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.h
@@ -45,27 +45,27 @@
 /*!
  @abstract The class name of the <PFObject> this collection will use as a datasource.
  */
-@property (nonatomic, copy) NSString *parseClassName;
+@property (nonatomic, copy) IBInspectable NSString *parseClassName;
 
 /*!
  @abstract Whether the collection should use the default loading view. Default - `YES`.
  */
-@property (nonatomic, assign) BOOL loadingViewEnabled;
+@property (nonatomic, assign) IBInspectable BOOL loadingViewEnabled;
 
 /*!
  @abstract Whether the collection should use the built-in pull-to-refresh feature. Defualt - `YES`.
  */
-@property (nonatomic, assign) BOOL pullToRefreshEnabled;
+@property (nonatomic, assign) IBInspectable BOOL pullToRefreshEnabled;
 
 /*!
  @abstract Whether the collection should use the built-in pagination feature. Default - `YES`.
  */
-@property (nonatomic, assign) BOOL paginationEnabled;
+@property (nonatomic, assign) IBInspectable BOOL paginationEnabled;
 
 /*!
  @abstract The number of objects to show per page. Default - `25`.
  */
-@property (nonatomic, assign) NSUInteger objectsPerPage;
+@property (nonatomic, assign) IBInspectable NSUInteger objectsPerPage;
 
 /*!
  @abstract Whether the collection is actively loading new data from the server.

--- a/ParseUIDemo/Classes/CustomViewControllers/QueryCollectionViewController/StoryboardCollectionViewController.m
+++ b/ParseUIDemo/Classes/CustomViewControllers/QueryCollectionViewController/StoryboardCollectionViewController.m
@@ -28,21 +28,6 @@
 @implementation StoryboardCollectionViewController
 
 #pragma mark -
-#pragma mark Init
-
-- (instancetype)initWithCoder:(NSCoder *)decoder {
-    self = [super initWithCoder:decoder];
-    if (!self) return nil;
-
-    self.title = @"Storyboard Collection";
-    self.parseClassName = @"Todo";
-    self.pullToRefreshEnabled = YES;
-    self.paginationEnabled = NO;
-
-    return self;
-}
-
-#pragma mark -
 #pragma mark UIViewController
 
 - (void)viewDidLoad {

--- a/ParseUIDemo/Classes/PFUIDemoViewController.m
+++ b/ParseUIDemo/Classes/PFUIDemoViewController.m
@@ -179,7 +179,6 @@ typedef NS_ENUM(uint8_t, PFUIDemoType) {
         case PFUIDemoTypeStoryboardCollection: {
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"SimpleQueryCollectionStoryboard" bundle:NULL];
             StoryboardCollectionViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"StoryboardCollectionViewController"];
-
             [self.navigationController pushViewController:controller animated:YES];
             break;
         }

--- a/ParseUIDemo/Resources/SimpleQueryCollectionStoryboard.storyboard
+++ b/ParseUIDemo/Resources/SimpleQueryCollectionStoryboard.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C94b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14D72i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
     </dependencies>
     <scenes>
-        <!--Storyboard Collection View Controller-->
+        <!--Storyboard Collection-->
         <scene sceneID="BVy-dg-7f5">
             <objects>
-                <collectionViewController storyboardIdentifier="StoryboardCollectionViewController" id="EI1-oL-qCe" customClass="StoryboardCollectionViewController" sceneMemberID="viewController">
+                <collectionViewController storyboardIdentifier="StoryboardCollectionViewController" title="Storyboard Collection" id="EI1-oL-qCe" customClass="StoryboardCollectionViewController" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="E4A-E4-mpj">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -34,10 +34,15 @@
                             <outlet property="delegate" destination="EI1-oL-qCe" id="SIB-7c-14a"/>
                         </connections>
                     </collectionView>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="parseClassName" value="Todo"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="pullToRefreshEnabled" value="YES"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="paginationEnabled" value="NO"/>
+                    </userDefinedRuntimeAttributes>
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="oRY-fp-vRF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-58" y="751"/>
+            <point key="canvasLocation" x="-101" y="209"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
`IBInspectable` allows editing these properties inline inside Interface Builder / Storyboard.
This simplifies setting up a PFQueryCollectionViewContorller when using Storyboards or Interface Builder.
 (as you can see - the code from an example was removed, and specified directly in Storyboard)

cc @hallucinogen, @grantland, @stanley-parse 