### PR TITLE
Fixed next page view in PFQueryCollectionViewController wrong position after reload.

### DIFF
--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
@@ -42,7 +42,7 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) PFLoadingView *loadingView;
 
-@property (nonatomic, strong) PFActivityIndicatorCollectionReusableView *nextPageView;
+@property (nonatomic, strong) PFActivityIndicatorCollectionReusableView *currentNextPageView;
 
 - (instancetype)initWithCoder:(NSCoder *)decoder NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
@@ -193,7 +193,7 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 
         if (error) {
             _lastLoadCount = -1;
-            _nextPageView.animating = NO;
+            _currentNextPageView.animating = NO;
         } else {
             _currentPage = page;
             _lastLoadCount = [foundObjects count];
@@ -215,7 +215,7 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 - (void)loadNextPage {
     if (!self.loading) {
         [self loadObjects:(_currentPage + 1) clear:NO];
-        _nextPageView.animating = YES;
+        _currentNextPageView.animating = YES;
     }
 }
 
@@ -267,15 +267,13 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 }
 
 - (UICollectionReusableView *)collectionViewReusableViewForNextPageAction:(UICollectionView *)collectionView {
-    if (!_nextPageView) {
-        _nextPageView = [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionFooter
-                                                           withReuseIdentifier:PFQueryCollectionViewNextPageReusableViewIdentifier
-                                                                  forIndexPath:[self _indexPathForPaginationReusableView]];
-        _nextPageView.textLabel.text = NSLocalizedString(@"Load more...", @"Load more...");
-        [_nextPageView addTarget:self action:@selector(loadNextPage) forControlEvents:UIControlEventTouchUpInside];
-    }
-    _nextPageView.animating = self.loading;
-    return _nextPageView;
+    _currentNextPageView = [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionFooter
+                                                                  withReuseIdentifier:PFQueryCollectionViewNextPageReusableViewIdentifier
+                                                                         forIndexPath:[self _indexPathForPaginationReusableView]];
+    _currentNextPageView.textLabel.text = NSLocalizedString(@"Load more...", @"Load more...");
+    [_currentNextPageView addTarget:self action:@selector(loadNextPage) forControlEvents:UIControlEventTouchUpInside];
+    _currentNextPageView.animating = self.loading;
+    return _currentNextPageView;
 }
 
 #pragma mark -


### PR DESCRIPTION
UICollectionView expects a new `UICollectionReusableView` to be returned or it won't reposition the old one.
- Rename a property to indicate that it's just `current*`
- Don't reuse the view, but create it every time UICollectionView asks for it

cc @grantland @hallucinogen @stanley-parse 

Fixes #42 