### PR TITLE
Infinite scrolling fix

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -118,6 +118,11 @@
  */
 @property (nonatomic, assign, getter=isLoading) BOOL loading;
 
+/*!
+ @abstract Whether the table should use built-in infinite scrolling feature.  Default - `NO`.
+ */
+@property (nonatomic, assign) BOOL infiniteScrolling;
+
 ///--------------------------------------
 /// @name Responding to Events
 ///--------------------------------------

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -385,7 +385,7 @@
     if (self.infiniteScrolling) {
         return NO;
     }
-    return [self _shouldLoadNextPage]
+    return [self _shouldLoadNextPage];
 }
 
 // There is another page?


### PR DESCRIPTION
Fixed infinite scrolling of PFQueryTableViewController of a previous pull request (#35)
If last page is already loaded, it avoid to call loadNextPage on scrolling.