### PR TITLE
Add support for using ParseUI with new CocoaPods dynamic frameworks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: objective-c
 before_install:
   - brew update
   - brew reinstall xctool
-  - gem install cocoapods --quiet
+  - gem install cocoapods --pre --quiet
   - pod setup --silent
   - pod repo update --silent
 script:
   - pod install
-  - pod lib lint
+  - pod lib lint ParseUI.podspec
+  - pod lib lint --use-frameworks --quick ParseUI.podspec
   - xctool -workspace ParseUI.xcworkspace -scheme 'ParseUI' -sdk iphonesimulator build
   - xctool -workspace ParseUI.xcworkspace -scheme 'ParseUIDemo' -sdk iphonesimulator build

--- a/ParseUI.podspec
+++ b/ParseUI.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |s|
                           'ParseUI/Classes/Views/*.h',
                           'ParseUI/Classes/Cells/*.h',
                           'ParseUI/Other/*.h'
+  s.xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup' }
   s.frameworks          = 'Foundation',
                           'UIKit',
                           'CoreGraphics',


### PR DESCRIPTION
When `use_frameworks!` is enabled - CocoaPods is trying to build a podspec as a dynamic framework.
ParseUI references symbols from Parse.framework (which is static at the moment) - which is not supported (Parse.framework is linked with the target app and not with ParseUI.framework).
This change enables dynamic symbol lookup (runtime) when using ParseUI as a dynamic framework.
I've also added a `pod lib lint --use-frameworks` to the `travis.yml` for CI to verify that this use-case works.

Fixes #51 

cc @grantland @hallucinogen @stanley-parse 