### PR TITLE
Fixed warnings surfaced in Xcode 6.3.

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -28,6 +28,17 @@
 #import "PFLoadingView.h"
 #import "PFTableViewCell.h"
 
+// Add headers to kill any warnings.
+// `initWithStyle:` is a UITableViewController method.
+// `initWithCoder:`/`initWithNibName:bundle:` are UIViewController methods and are, for sure, available.
+@interface UITableViewController ()
+
+- (instancetype)initWithStyle:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder *)decoder NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
+
+@end
+
 @interface PFQueryTableViewController () {
     NSMutableArray *_mutableObjects;
 

--- a/ParseUIDemo/Classes/PFUIDemoViewController.m
+++ b/ParseUIDemo/Classes/PFUIDemoViewController.m
@@ -120,6 +120,10 @@ typedef NS_ENUM(uint8_t, PFUIDemoType) {
     return self;
 }
 
+- (instancetype)initWithStyle:(UITableViewStyle)style {
+    return [self init];
+}
+
 #pragma mark -
 #pragma mark UITableViewDataSource
 


### PR DESCRIPTION
Xcode 6.3 has slightly different headers for UIKit (specifically for UITableViewController), which makes our code fire warnings.
This code change just silences the warnings (as there are no problems).

cc @grantland @hallucinogen @stanley-parse 