### PR TITLE
Add backward-compatible nullability annotations to all public classes.

### DIFF
--- a/ParseUI/Classes/Cells/PFCollectionViewCell.h
+++ b/ParseUI/Classes/Cells/PFCollectionViewCell.h
@@ -21,6 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
+
 @class PFImageView;
 @class PFObject;
 
@@ -50,6 +54,8 @@
 
  @param object An instance of `PFObject` to update from.
  */
-- (void)updateFromObject:(PFObject *)object;
+- (void)updateFromObject:(PFUI_NULLABLE PFObject *)object;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/Cells/PFPurchaseTableViewCell.h
+++ b/ParseUI/Classes/Cells/PFPurchaseTableViewCell.h
@@ -21,7 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
 #import <ParseUI/PFTableViewCell.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
 
 /*!
  An enum that represents states of the PFPurchaseTableViewCell.
@@ -53,11 +56,13 @@ typedef NS_ENUM(uint8_t, PFPurchaseTableViewCellState) {
 /*!
  @abstract Label where price of the product is displayed.
  */
-@property (nonatomic, strong, readonly) UILabel *priceLabel;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UILabel *priceLabel;
 
 /*!
  @abstract Progress view that is shown, when the product is downloading.
  */
-@property (nonatomic, strong, readonly) UIProgressView *progressView;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIProgressView *progressView;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/Cells/PFTableViewCell.h
+++ b/ParseUI/Classes/Cells/PFTableViewCell.h
@@ -21,7 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
 #import <ParseUI/PFImageView.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
 
 /*!
  The `PFTableViewCell` class represents a table view cell which can download and display remote images stored on Parse.
@@ -36,6 +39,8 @@
 
  @see PFImageView
  */
-@property (nonatomic, strong, readonly) PFImageView *imageView;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFImageView *imageView;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/LogInViewController/PFLogInView.h
+++ b/ParseUI/Classes/LogInViewController/PFLogInView.h
@@ -23,6 +23,8 @@
 
 #import <ParseUI/ParseUIConstants.h>
 
+PFUI_ASSUME_NONNULL_BEGIN
+
 /*!
  `PFLogInFields` bitmask specifies the log in elements which are enabled in the view.
 
@@ -82,14 +84,14 @@ typedef NS_OPTIONS(NSInteger, PFLogInFields) {
 
  @discussion Used to lay out elements correctly when the presenting view controller has translucent elements.
  */
-@property (nonatomic, weak) UIViewController *presentingViewController;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, weak) UIViewController *presentingViewController;
 
 ///--------------------------------------
 /// @name Customizing the Logo
 ///--------------------------------------
 
 /// The logo. By default, it is the Parse logo.
-@property (nonatomic, strong) UIView *logo;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong) UIView *logo;
 
 ///--------------------------------------
 /// @name Configure Username Behaviour
@@ -114,55 +116,57 @@ typedef NS_OPTIONS(NSInteger, PFLogInFields) {
 /*!
  @abstract The username text field. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) PFTextField *usernameField;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFTextField *usernameField;
 
 /*!
  @abstract The password text field. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) PFTextField *passwordField;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFTextField *passwordField;
 
 /*!
  @abstract The password forgotten button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *passwordForgottenButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *passwordForgottenButton;
 
 /*!
  @abstract The log in button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *logInButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *logInButton;
 
 /*!
  @abstract The Facebook button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *facebookButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *facebookButton;
 
 /*!
  @abstract The Twitter button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *twitterButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *twitterButton;
 
 /*!
  @abstract The sign up button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *signUpButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *signUpButton;
 
 /*!
  @abstract It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *dismissButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *dismissButton;
 
 /*!
  @abstract The facebook/twitter login label.
 
  @deprecated This property is deprecated and will always be nil.
  */
-@property (nonatomic, strong, readonly) UILabel *externalLogInLabel __attribute__(PARSE_UI_DEPRECATED("This property is deprecated and will always be nil."));
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UILabel *externalLogInLabel __attribute__(PARSE_UI_DEPRECATED("This property is deprecated and will always be nil."));
 
 /*!
  @abstract The sign up label.
 
  @deprecated This property is deprecated and will always be nil.
  */
-@property (nonatomic, strong, readonly) UILabel *signUpLabel __attribute__(PARSE_UI_DEPRECATED("This property is deprecated and will always be nil."));
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UILabel *signUpLabel __attribute__(PARSE_UI_DEPRECATED("This property is deprecated and will always be nil."));
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.h
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.h
@@ -21,7 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
 #import <ParseUI/PFLogInView.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
 
 @class PFSignUpViewController;
 @class PFUser;
@@ -49,7 +52,7 @@
 
  @see PFLogInView
  */
-@property (nonatomic, strong, readonly) PFLogInView *logInView;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFLogInView *logInView;
 
 ///--------------------------------------
 /// @name Configuring Log In Behaviors
@@ -60,14 +63,14 @@
 
  @see PFLogInViewControllerDelegate
  */
-@property (nonatomic, weak) id<PFLogInViewControllerDelegate> delegate;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, weak) id<PFLogInViewControllerDelegate> delegate;
 
 /*!
  @abstract The facebook permissions that Facebook log in requests for.
 
  @discussion If unspecified, the default is basic facebook permissions.
  */
-@property (nonatomic, copy) NSArray *facebookPermissions;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, copy) NSArray *facebookPermissions;
 
 /*!
  @abstract The sign up controller if sign up is enabled.
@@ -75,7 +78,7 @@
  @discussion Use this to configure the sign up view, and the transition animation to the sign up view.
  The default is a sign up view with a username, a password, a dismiss button and a sign up button.
  */
-@property (nonatomic, strong) PFSignUpViewController *signUpController;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong) PFSignUpViewController *signUpController;
 
 /*!
  @abstract Whether to prompt for the email as username on the login view.
@@ -155,7 +158,8 @@ shouldBeginLogInWithUsername:(NSString *)username
  @param logInController The login view controller where login failed.
  @param error `NSError` object representing the error that occured.
  */
-- (void)logInViewController:(PFLogInViewController *)logInController didFailToLogInWithError:(NSError *)error;
+- (void)logInViewController:(PFLogInViewController *)logInController
+    didFailToLogInWithError:(PFUI_NULLABLE NSError *)error;
 
 /*!
  @abstract Sent to the delegate when the log in screen is cancelled.
@@ -165,3 +169,5 @@ shouldBeginLogInWithUsername:(NSString *)username
 - (void)logInViewControllerDidCancelLogIn:(PFLogInViewController *)logInController;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/ProductTableViewController/PFProductTableViewController.h
+++ b/ParseUI/Classes/ProductTableViewController/PFProductTableViewController.h
@@ -19,7 +19,12 @@
  *
  */
 
+#import <UIKit/UIKit.h>
+
+#import <ParseUI/ParseUIConstants.h>
 #import <ParseUI/PFQueryTableViewController.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
 
 /*!
  `PFProductTableViewController` displays in-app purchase products stored on Parse.
@@ -38,3 +43,5 @@
 - (instancetype)initWithStyle:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.h
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.h
@@ -21,6 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
+
 @class PFCollectionViewCell;
 @class PFObject;
 @class PFQuery;
@@ -45,7 +49,7 @@
 /*!
  @abstract The class name of the <PFObject> this collection will use as a datasource.
  */
-@property (nonatomic, copy) IBInspectable NSString *parseClassName;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, copy) IBInspectable NSString *parseClassName;
 
 /*!
  @abstract Whether the collection should use the default loading view. Default - `YES`.
@@ -84,7 +88,7 @@
 
  @returns An initialized `PFQueryCollectionViewController` object or `nil` if the object couldn't be created.
  */
-- (instancetype)initWithClassName:(NSString *)className;
+- (instancetype)initWithClassName:(PFUI_NULLABLE NSString *)className;
 
 /*!
  @abstract Initializes a view controller with a class name of <PFObject> that will be associated with this collection.
@@ -94,7 +98,8 @@
 
  @returns An initialized `PFQueryCollectionViewController` object or `nil` if the object couldn't be created.
  */
-- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout className:(NSString *)className NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
+                                   className:(PFUI_NULLABLE NSString *)className NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
 /// @name Responding to Events
@@ -111,7 +116,7 @@
  call [super objectsDidLoad:] in your implementation.
  @param error The Parse error from running the PFQuery, if there was any.
  */
-- (void)objectsDidLoad:(NSError *)error NS_REQUIRES_SUPER;
+- (void)objectsDidLoad:(PFUI_NULLABLE NSError *)error NS_REQUIRES_SUPER;
 
 ///--------------------------------------
 /// @name Accessing Results
@@ -132,7 +137,7 @@
 
  @returns The object at the specified indexPath.
  */
-- (PFObject *)objectAtIndexPath:(NSIndexPath *)indexPath;
+- (PFUI_NULLABLE PFObject *)objectAtIndexPath:(PFUI_NULLABLE NSIndexPath *)indexPath;
 
 ///--------------------------------------
 /// @name Loading Data
@@ -188,9 +193,9 @@
 
  @returns The cell that represents this object.
  */
-- (PFCollectionViewCell *)collectionView:(UICollectionView *)collectionView
-                  cellForItemAtIndexPath:(NSIndexPath *)indexPath
-                                  object:(PFObject *)object;
+- (PFUI_NULLABLE PFCollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                                cellForItemAtIndexPath:(NSIndexPath *)indexPath
+                                                object:(PFUI_NULLABLE PFObject *)object;
 
 /*!
  @discussion Override this method to customize the view that allows the user to load the
@@ -200,6 +205,8 @@
 
  @returns The view that allows the user to paginate.
  */
-- (UICollectionReusableView *)collectionViewReusableViewForNextPageAction:(UICollectionView *)collectionView;
+- (PFUI_NULLABLE UICollectionReusableView *)collectionViewReusableViewForNextPageAction:(UICollectionView *)collectionView;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -21,6 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
+
 @class PFObject;
 @class PFQuery;
 @class PFTableViewCell;
@@ -52,7 +56,8 @@
 
  @returns An initialized `PFQueryTableViewController` object or `nil` if the object couldn't be created.
  */
-- (instancetype)initWithStyle:(UITableViewStyle)style className:(NSString *)className NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithStyle:(UITableViewStyle)style
+                    className:(PFUI_NULLABLE NSString *)className NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Initializes with a class name of the PFObjects that will be associated with this table.
@@ -61,7 +66,7 @@
 
  @returns An initialized `PFQueryTableViewController` object or `nil` if the object couldn't be created.
  */
-- (instancetype)initWithClassName:(NSString *)className;
+- (instancetype)initWithClassName:(PFUI_NULLABLE NSString *)className;
 
 ///--------------------------------------
 /// @name Configuring Behavior
@@ -70,28 +75,28 @@
 /*!
  @abstract The class name of the <PFObject> this table will use as a datasource.
  */
-@property (nonatomic, copy) IBInspectable NSString *parseClassName;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, copy) IBInspectable NSString *parseClassName;
 
 /*!
  @abstract The key to use to display for the cell text label.
 
  @discussion This won't apply if you override <tableView:cellForRowAtIndexPath:object:>
  */
-@property (nonatomic, copy) IBInspectable NSString *textKey;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, copy) IBInspectable NSString *textKey;
 
 /*!
  @abstract The key to use to display for the cell image view.
 
  @discussion This won't apply if you override <tableView:cellForRowAtIndexPath:object:>
  */
-@property (nonatomic, copy) IBInspectable NSString *imageKey;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, copy) IBInspectable NSString *imageKey;
 
 /*!
  @abstract The image to use as a placeholder for the cell images.
 
  @discussion This won't apply if you override <tableView:cellForRowAtIndexPath:object:>
  */
-@property (nonatomic, strong) IBInspectable UIImage *placeholderImage;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong) IBInspectable UIImage *placeholderImage;
 
 /*!
  @abstract Whether the table should use the default loading view. Default - `YES`.
@@ -133,7 +138,7 @@
  call [super objectsDidLoad:] in your implementation.
  @param error The Parse error from running the PFQuery, if there was any.
  */
-- (void)objectsDidLoad:(NSError *)error;
+- (void)objectsDidLoad:(PFUI_NULLABLE NSError *)error;
 
 ///--------------------------------------
 /// @name Accessing Results
@@ -142,7 +147,7 @@
 /*!
  @abstract The array of instances of <PFObject> that is used as a data source.
  */
-@property (nonatomic, copy, readonly) NSArray *objects;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, copy, readonly) NSArray *objects;
 
 /*!
  @abstract Returns an object at a particular indexPath.
@@ -154,7 +159,7 @@
 
  @returns The object at the specified index
  */
-- (PFObject *)objectAtIndexPath:(NSIndexPath *)indexPath;
+- (PFUI_NULLABLE PFObject *)objectAtIndexPath:(PFUI_NULLABLE NSIndexPath *)indexPath;
 
 /*!
  @abstract Clears the table of all objects.
@@ -208,9 +213,9 @@
 
  @returns The cell that represents this object.
  */
-- (PFTableViewCell *)tableView:(UITableView *)tableView
-         cellForRowAtIndexPath:(NSIndexPath *)indexPath
-                        object:(PFObject *)object;
+- (PFUI_NULLABLE PFTableViewCell *)tableView:(UITableView *)tableView
+                       cellForRowAtIndexPath:(NSIndexPath *)indexPath
+                                      object:(PFUI_NULLABLE PFObject *)object;
 
 /*!
  @discussion Override this method to customize the cell that allows the user to load the
@@ -221,6 +226,9 @@
 
  @returns The cell that allows the user to paginate.
  */
-- (PFTableViewCell *)tableView:(UITableView *)tableView cellForNextPageAtIndexPath:(NSIndexPath *)indexPath;
+- (PFUI_NULLABLE PFTableViewCell *)tableView:(UITableView *)tableView
+                  cellForNextPageAtIndexPath:(NSIndexPath *)indexPath;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/SignUpViewController/PFSignUpView.h
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpView.h
@@ -21,6 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
+
 /*!
  `PFSignUpFields` bitmask specifies the sign up elements which are enabled in the view.
 
@@ -72,7 +76,7 @@ typedef NS_OPTIONS(NSInteger, PFSignUpFields) {
 
  @discussion Used to lay out elements correctly when the presenting view controller has translucent elements.
  */
-@property (nonatomic, weak) UIViewController *presentingViewController;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, weak) UIViewController *presentingViewController;
 
 ///--------------------------------------
 /// @name Customizing the Logo
@@ -81,7 +85,7 @@ typedef NS_OPTIONS(NSInteger, PFSignUpFields) {
 /*!
  @abstract The logo. By default, it is the Parse logo.
  */
-@property (nonatomic, strong) UIView *logo;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong) UIView *logo;
 
 ///--------------------------------------
 /// @name Configure Username Behaviour
@@ -106,33 +110,35 @@ typedef NS_OPTIONS(NSInteger, PFSignUpFields) {
 /*!
  @abstract The username text field.
  */
-@property (nonatomic, strong, readonly) PFTextField *usernameField;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFTextField *usernameField;
 
 /*!
  @abstract The password text field.
  */
-@property (nonatomic, strong, readonly) PFTextField *passwordField;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFTextField *passwordField;
 
 /*!
  @abstract The email text field. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) PFTextField *emailField;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFTextField *emailField;
 
 /*!
  @abstract The additional text field. It is `nil` if the element is not enabled.
 
  @discussion This field is intended to be customized.
  */
-@property (nonatomic, strong, readonly) PFTextField *additionalField;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFTextField *additionalField;
 
 /*!
  @abstract The sign up button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *signUpButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *signUpButton;
 
 /*!
  @abstract The dismiss button. It is `nil` if the element is not enabled.
  */
-@property (nonatomic, strong, readonly) UIButton *dismissButton;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) UIButton *dismissButton;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.h
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.h
@@ -21,10 +21,13 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
 #import <ParseUI/PFSignUpView.h>
 
 @class PFUser;
 @protocol PFSignUpViewControllerDelegate;
+
+PFUI_ASSUME_NONNULL_BEGIN
 
 /*!
  The `PFSignUpViewController` class that presents and manages
@@ -48,7 +51,7 @@
 
  @see PFSignUpView
  */
-@property (nonatomic, strong, readonly) PFSignUpView *signUpView;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong, readonly) PFSignUpView *signUpView;
 
 ///--------------------------------------
 /// @name Configuring Sign Up Behaviors
@@ -59,7 +62,7 @@
 
  @see PFSignUpViewControllerDelegate
  */
-@property (nonatomic, weak) id<PFSignUpViewControllerDelegate> delegate;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, weak) id<PFSignUpViewControllerDelegate> delegate;
 
 /*!
  @abstract Minimum required password length for user signups, defaults to `0`.
@@ -142,7 +145,8 @@ extern NSString *const PFSignUpCancelNotification;
  @param signUpController The signup view controller where signup failed.
  @param error `NSError` object representing the error that occured.
  */
-- (void)signUpViewController:(PFSignUpViewController *)signUpController didFailToSignUpWithError:(NSError *)error;
+- (void)signUpViewController:(PFSignUpViewController *)signUpController
+    didFailToSignUpWithError:(PFUI_NULLABLE NSError *)error;
 
 /*!
  @abstract Sent to the delegate when the sign up screen is cancelled.
@@ -152,3 +156,5 @@ extern NSString *const PFSignUpCancelNotification;
 - (void)signUpViewControllerDidCancelSignUp:(PFSignUpViewController *)signUpController;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/Views/PFImageView.h
+++ b/ParseUI/Classes/Views/PFImageView.h
@@ -21,6 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
+
 @class BFTask;
 @class PFFile;
 
@@ -34,7 +38,7 @@
 
  @warning Note that the download does not start until <loadInBackground:> is called.
  */
-@property (nonatomic, strong) PFFile *file;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong) PFFile *file;
 
 /*!
  @abstract Initiate downloading of the remote image.
@@ -52,7 +56,7 @@
 
  @param completion the completion block.
  */
-- (void)loadInBackground:(void (^)(UIImage *image, NSError *error))completion;
+- (void)loadInBackground:(PFUI_NULLABLE void (^)(PFUI_NULLABLE_S UIImage *image, PFUI_NULLABLE_S NSError *error))completion;
 
 /*!
  @abstract Initiate downloading of the remote image.
@@ -63,6 +67,9 @@
  @param progressBlock called with the download progress as the image is being downloaded. 
  Will be called with a value of 100 before the completion block is called.
  */
-- (void)loadInBackground:(void (^)(UIImage *, NSError *))completion progressBlock:(void (^)(int percentDone))progressBlock;
+- (void)loadInBackground:(PFUI_NULLABLE void (^)(PFUI_NULLABLE_S UIImage *image, PFUI_NULLABLE_S NSError *error))completion
+           progressBlock:(PFUI_NULLABLE void (^)(int percentDone))progressBlock;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/Views/PFTextField.h
+++ b/ParseUI/Classes/Views/PFTextField.h
@@ -21,6 +21,10 @@
 
 #import <UIKit/UIKit.h>
 
+#import <ParseUI/ParseUIConstants.h>
+
+PFUI_ASSUME_NONNULL_BEGIN
+
 /*!
  `PFTextFieldSeparatorStyle` bitmask specifies the style of the separators,
  that should be used for a given `PFTextField`.
@@ -56,7 +60,7 @@ typedef NS_OPTIONS(uint8_t, PFTextFieldSeparatorStyle){
 
  @discussion Default: `227,227,227,1.0`.
  */
-@property (nonatomic, strong) UIColor *separatorColor UI_APPEARANCE_SELECTOR;
+@property (PFUI_NULLABLE_PROPERTY nonatomic, strong) UIColor *separatorColor UI_APPEARANCE_SELECTOR;
 
 /*!
  This method is a convenience initializer that sets both `frame` and `separatorStyle` for an instance of `PFTextField.`
@@ -69,3 +73,5 @@ typedef NS_OPTIONS(uint8_t, PFTextFieldSeparatorStyle){
 - (instancetype)initWithFrame:(CGRect)frame separatorStyle:(PFTextFieldSeparatorStyle)separatorStyle;
 
 @end
+
+PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Other/ParseUIConstants.h
+++ b/ParseUI/Other/ParseUIConstants.h
@@ -19,19 +19,58 @@
  *
  */
 
+#import <Availability.h>
+#import <TargetConditionals.h>
+
 #ifndef ParseUI_ParseUIConstants_h
 #define ParseUI_ParseUIConstants_h
 
+///--------------------------------------
+/// @name Deprecated Macros
+///--------------------------------------
+
 #ifndef PARSE_UI_DEPRECATED
-    #ifdef __deprecated_msg
-        #define PARSE_UI_DEPRECATED(_MSG) (deprecated(_MSG))
-    #else
-        #ifdef __deprecated
-            #define PARSE_UI_DEPRECATED(_MSG) (deprecated)
-        #else
-            #define PARSE_UI_DEPRECATED(_MSG)
-        #endif
-    #endif
+#  ifdef __deprecated_msg
+#    define PARSE_UI_DEPRECATED(_MSG) (deprecated(_MSG))
+#  else
+#    ifdef __deprecated
+#      define PARSE_UI_DEPRECATED(_MSG) (deprecated)
+#    else
+#      define PARSE_UI_DEPRECATED(_MSG)
+#    endif
+#  endif
+#endif
+
+///--------------------------------------
+/// @name Nullability Support
+///--------------------------------------
+
+#if __has_feature(nullability)
+#  define PFUI_NULLABLE nullable
+#  define PFUI_NULLABLE_S __nullable
+#  define PFUI_NULL_UNSPECIFIED null_unspecified
+#  define PFUI_NULLABLE_PROPERTY nullable,
+#else
+#  define PFUI_NULLABLE
+#  define PFUI_NULLABLE_S
+#  define PFUI_NULL_UNSPECIFIED
+#  define PFUI_NULLABLE_PROPERTY
+#endif
+
+#if __has_feature(assume_nonnull)
+#  ifdef NS_ASSUME_NONNULL_BEGIN
+#    define PFUI_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_BEGIN
+#  else
+#    define PFUI_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#  endif
+#  ifdef NS_ASSUME_NONNULL_END
+#    define PFUI_ASSUME_NONNULL_END NS_ASSUME_NONNULL_END
+#  else
+#    define PFUI_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
+#  endif
+#else
+#  define PFUI_ASSUME_NONNULL_BEGIN
+#  define PFUI_ASSUME_NONNULL_END
 #endif
 
 #endif


### PR DESCRIPTION
Xcode 6.3 and Swift 1.2 along with LLVM 6.1 add support for Obj-C Nullability Annotations for parameters, return types, properties, variables, etc.
The nullability qualifiers affect the optionality of the Objective-C APIs when used in Swift as well as will show warnings when used in ObjC.
This adds backward-compatible (this code works on Xcode 6.0 and 6.1) support for this. When running on old Xcode - it simply is skipped and does not do anything.

More on the topic:
http://adcdownload.apple.com//Developer_Tools/Xcode_6.3_beta/Xcode_6.3_beta_Release_Notes.pdf
http://nshipster.com/swift-1.2/


cc @grantland @hramos @stanley-parse @hallucinogen
