### PR TITLE
Fixed sign up when automatic user creation is enabled.

### DIFF
--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
@@ -21,6 +21,7 @@
 
 #import "PFSignUpViewController.h"
 
+#import <Parse/PFAnonymousUtils.h>
 #import <Parse/PFConstants.h>
 #import <Parse/PFUser.h>
 
@@ -277,8 +278,14 @@ static NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"addit
 
         return;
     }
-
-    PFUser *user = [PFUser user];
+	
+	PFUser *user = nil;
+	if ([PFUser currentUser] && [PFAnonymousUtils isLinkedWithUser:[PFUser currentUser]]) {
+		user = [PFUser currentUser];
+	}
+	else {
+		user = [PFUser user];
+	}
     user.username = username;
     user.password = password;
 


### PR DESCRIPTION
Currently, the `PFSignUpViewController` always creates a new `PFUser` object. If `[PFUser enableAutomaticUser]` is set, the sign-up request (silently) fails, leading to a blocked sign-up view. This commit checks for an anonymous current user and completes the registration process instead of creating a new (independent) user object.