### PR TITLE
Fixed potential duplicate visible loading view in PFQueryTableViewController, PFQueryCollectionViewController.

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -113,11 +113,6 @@
 - (void)loadView {
     [super loadView];
 
-    if (self.loadingViewEnabled) {
-        self.loadingView = [[PFLoadingView alloc] initWithFrame:CGRectZero];
-        [self.tableView addSubview:self.loadingView];
-    }
-
     // Setup the Pull to Refresh UI if needed
     if (self.pullToRefreshEnabled) {
         UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
@@ -148,6 +143,7 @@
         _savedSeparatorStyle = self.tableView.separatorStyle;
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     }
+    [self _refreshLoadingView];
 }
 
 - (void)objectsDidLoad:(NSError *)error {
@@ -155,8 +151,7 @@
         _firstLoad = NO;
         self.tableView.separatorStyle = _savedSeparatorStyle;
     }
-    [self.loadingView removeFromSuperview];
-    self.loadingView = nil;
+    [self _refreshLoadingView];
 }
 
 - (PFQuery *)queryForTable {
@@ -235,8 +230,8 @@
 
 - (void)loadNextPage {
     if (!self.loading) {
-      [self loadObjects:(_currentPage + 1) clear:NO];
-      [self _refreshPaginationCell];
+        [self loadObjects:(_currentPage + 1) clear:NO];
+        [self _refreshPaginationCell];
     }
 }
 
@@ -422,6 +417,31 @@
 
 - (NSArray *)objects {
     return _mutableObjects;
+}
+
+#pragma mark -
+#pragma mark Loading View
+
+- (void)_refreshLoadingView {
+    BOOL showLoadingView = self.loadingViewEnabled && self.loading && _firstLoad;
+
+    if (showLoadingView) {
+        [self.tableView addSubview:self.loadingView];
+        [self.view setNeedsLayout];
+    } else {
+        // Avoid loading `loadingView` - just use an ivar.
+        if (_loadingView) {
+            [self.loadingView removeFromSuperview];
+            self.loadingView = nil;
+        }
+    }
+}
+
+- (PFLoadingView *)loadingView {
+    if (!_loadingView) {
+        _loadingView = [[PFLoadingView alloc] initWithFrame:CGRectZero];
+    }
+    return _loadingView;
 }
 
 @end


### PR DESCRIPTION
If `loadingView` is visible and refresh is triggered once again through `refreshControl` - it loads another `PFLoadingView` and adds it as a subview - which makes 2 visible loading views and the first one becomes not accessible and not removable any more. This PR fixes this problem and fixes #64.


cc @grantland @hallucinogen @stanley-parse 