### PR TITLE
Add support for ParseFacebookUtilsV4 and FBSDKv4.

### DIFF
--- a/ParseUI.podspec
+++ b/ParseUI.podspec
@@ -33,6 +33,5 @@ Pod::Spec.new do |s|
                           'CoreGraphics',
                           'QuartzCore'
 
-  s.dependency 'Parse', '~> 1.6'
-  s.dependency 'ParseFacebookUtils', '~> 1.6'
+  s.dependency 'Parse', '~> 1.7'
 end

--- a/ParseUI.xcodeproj/project.pbxproj
+++ b/ParseUI.xcodeproj/project.pbxproj
@@ -811,7 +811,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = PF;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Parse Inc.";
 				TargetAttributes = {
 					81472F661A1AB33800FD6EED = {
@@ -1219,7 +1219,7 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = ParseUIDemo/Other/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1251,7 +1251,7 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = ParseUIDemo/Other/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ParseUI.xcodeproj/xcshareddata/xcschemes/ParseUI.xcscheme
+++ b/ParseUI.xcodeproj/xcshareddata/xcschemes/ParseUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ParseUI.xcodeproj/xcshareddata/xcschemes/ParseUIDemo-Swift.xcscheme
+++ b/ParseUI.xcodeproj/xcshareddata/xcschemes/ParseUIDemo-Swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,7 +48,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8129E5DE1A9CB067006752BC"
@@ -66,7 +67,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8129E5DE1A9CB067006752BC"

--- a/ParseUI.xcodeproj/xcshareddata/xcschemes/ParseUIDemo.xcscheme
+++ b/ParseUI.xcodeproj/xcshareddata/xcschemes/ParseUIDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,7 +48,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "81472F661A1AB33800FD6EED"
@@ -66,7 +67,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "81472F661A1AB33800FD6EED"

--- a/ParseUIDemo/Classes/AppDelegate.m
+++ b/ParseUIDemo/Classes/AppDelegate.m
@@ -22,8 +22,8 @@
 #import "AppDelegate.h"
 
 #import <Parse/Parse.h>
-
-#import <ParseFacebookUtils/PFFacebookUtils.h>
+#import <ParseFacebookUtilsV4/PFFacebookUtils.h>
+#import <FBSDKCoreKit/FBSDKApplicationDelegate.h>
 
 #import "PFUIDemoViewController.h"
 
@@ -35,7 +35,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [Parse setApplicationId:@"UdNpOP2XFoEiXLZEBDl6xONmCMH8VjETmnEsl0xJ"
                   clientKey:@"wNJFho0fQaQFQ2Fe1x9b67lVBakJiAtFj1Uz30A9"];
-    [PFFacebookUtils initializeFacebook];
+    [PFFacebookUtils initializeFacebookWithApplicationLaunchOptions:launchOptions];
     [PFTwitterUtils initializeWithConsumerKey:@"3Q9hMEKqqSg4ie2pibZ2sVJuv"
                                consumerSecret:@"IEZ9wv2d1EpXNGFKGp7sAGdxRtyqtPwygyciFZwTHTGhPp4FMj"];
 
@@ -54,13 +54,10 @@
             openURL:(NSURL *)url
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation {
-    return [FBAppCall handleOpenURL:url
-                  sourceApplication:sourceApplication
-                        withSession:[PFFacebookUtils session]];
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    [FBAppCall handleDidBecomeActiveWithSession:[PFFacebookUtils session]];
+    return [[FBSDKApplicationDelegate sharedInstance] application:application
+                                                          openURL:url
+                                                sourceApplication:sourceApplication
+                                                       annotation:annotation];
 }
 
 #pragma mark -

--- a/ParseUIDemo/Swift/AppDelegate.swift
+++ b/ParseUIDemo/Swift/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         Parse.setApplicationId("UdNpOP2XFoEiXLZEBDl6xONmCMH8VjETmnEsl0xJ", clientKey: "wNJFho0fQaQFQ2Fe1x9b67lVBakJiAtFj1Uz30A9")
-        PFFacebookUtils.initializeFacebook()
+        PFFacebookUtils.initializeFacebookWithApplicationLaunchOptions(launchOptions);
         PFTwitterUtils.initializeWithConsumerKey("3Q9hMEKqqSg4ie2pibZ2sVJuv", consumerSecret: "IEZ9wv2d1EpXNGFKGp7sAGdxRtyqtPwygyciFZwTHTGhPp4FMj")
 
         window = UIWindow(frame: UIScreen.mainScreen().bounds)
@@ -46,11 +46,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
-        return FBAppCall.handleOpenURL(url, sourceApplication: sourceApplication, withSession: PFFacebookUtils.session())
-    }
-
-    func applicationDidBecomeActive(application: UIApplication) {
-        FBAppCall.handleDidBecomeActiveWithSession(PFFacebookUtils.session())
+        return FBSDKApplicationDelegate.sharedInstance().application(application, openURL: url, sourceApplication: sourceApplication, annotation: annotation)
     }
 
     // MARK: Test Data

--- a/ParseUIDemo/Swift/ParseUIDemo-Bridging-Header.h
+++ b/ParseUIDemo/Swift/ParseUIDemo-Bridging-Header.h
@@ -23,6 +23,7 @@
 #define ParseStarterProject_Bridging_Header_h
 
 #import <Bolts/Bolts.h>
-#import <ParseFacebookUtils/PFFacebookUtils.h>
+#import <ParseFacebookUtilsV4/PFFacebookUtils.h>
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
 
 #endif

--- a/Podfile
+++ b/Podfile
@@ -3,6 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ParseUI'
 xcodeproj 'ParseUI.xcodeproj'
 link_with 'ParseUIDemo'
+platform :ios, "7.0"
 
-pod 'Parse', '~> 1.6'
-pod 'ParseFacebookUtils', '~> 1.6'
+pod 'Parse', '~> 1.7'
+pod 'ParseFacebookUtilsV4', '~> 1.7'


### PR DESCRIPTION
This adds support for ParseFacebookUtilsV4 and FBSDKv4.
Please note that ParseUI pod and built framework still support both V3 and V4, as both are linked lazily and there is no more hard dependency.

cc @hallucinogen @stanleyw @grantland @andrewimm 

Fixes #68 