### PR TITLE
We need to be able to override _indexPathForPaginationCell in our app

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -229,6 +229,8 @@ PFUI_ASSUME_NONNULL_BEGIN
 - (PFUI_NULLABLE PFTableViewCell *)tableView:(UITableView *)tableView
                   cellForNextPageAtIndexPath:(NSIndexPath *)indexPath;
 
+- (NSIndexPath *)indexPathForPaginationCell;
+
 @end
 
 PFUI_ASSUME_NONNULL_END

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -333,7 +333,7 @@
 
 - (UITableViewCell *)tableView:(UITableView *)otherTableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     PFTableViewCell *cell;
-    if ([self _shouldShowPaginationCell] && [indexPath isEqual:[self _indexPathForPaginationCell]]) {
+    if ([self _shouldShowPaginationCell] && [indexPath isEqual:[self indexPathForPaginationCell]]) {
         // Return the pagination cell on the last cell
         cell = [self tableView:otherTableView cellForNextPageAtIndexPath:indexPath];
     } else {
@@ -355,6 +355,11 @@
     return cell;
 }
 
+// The row of the pagination cell
+- (NSIndexPath *)indexPathForPaginationCell {
+    return [NSIndexPath indexPathForRow:[self.objects count] inSection:0];
+}
+
 #pragma mark -
 #pragma mark UITableViewDelegate
 
@@ -362,7 +367,7 @@
     // Handle selection of the next page row
     if (!_firstLoad &&
         self.paginationEnabled &&
-        [indexPath isEqual:[self _indexPathForPaginationCell]]) {
+        [indexPath isEqual:[self indexPathForPaginationCell]]) {
         [self loadNextPage];
     }
 }
@@ -380,14 +385,9 @@
 // Selectively refresh pagination cell
 - (void)_refreshPaginationCell {
     if ([self _shouldShowPaginationCell]) {
-        [self.tableView reloadRowsAtIndexPaths:@[ [self _indexPathForPaginationCell] ]
+        [self.tableView reloadRowsAtIndexPaths:@[ [self indexPathForPaginationCell] ]
                               withRowAnimation:UITableViewRowAnimationNone];
     }
-}
-
-// The row of the pagination cell
-- (NSIndexPath *)_indexPathForPaginationCell {
-    return [NSIndexPath indexPathForRow:[self.objects count] inSection:0];
 }
 
 - (void)_loadImagesForOnscreenRows {


### PR DESCRIPTION
We need to be able to override _indexPathForPaginationCell in our app, since we are injecting our own PFObjects at the beginning or end of the table view.

For example, we are adding "uploading status" cells to the top of the table if an upload is in progress.