### PR TITLE
Fix a crash caused by returning a nil supplementary element

### DIFF
--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
@@ -351,12 +351,7 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView
            viewForSupplementaryElementOfKind:(NSString *)kind
                                  atIndexPath:(NSIndexPath *)indexPath {
-    if ([self _shouldShowPaginationView] &&
-        [kind isEqualToString:UICollectionElementKindSectionFooter] &&
-        [indexPath isEqual:[self _indexPathForPaginationReusableView]]) {
-        return [self collectionViewReusableViewForNextPageAction:collectionView];
-    }
-    return nil;
+    return [self collectionViewReusableViewForNextPageAction:collectionView];
 }
 
 #pragma mark -


### PR DESCRIPTION
Remove the possibility of returning nil from the `collectionView:viewForSupplementaryElementOfKind:atIndexPath:` method in order to make it compliant with Apple's documentation which states: "This method must always return a valid view object." If this method returns nil for any reason, it causes a crash. See #66.