### PR TITLE
Threading issue fixed in PFImageView

### DIFF
--- a/ParseUI/Classes/Views/PFImageView.m
+++ b/ParseUI/Classes/Views/PFImageView.m
@@ -127,17 +127,11 @@
                 return;
             }
 
-            if (file != _file) {
-                // a latter issued loadInBackground has replaced the file being loaded
-                if (completion) {
-                    completion(image, nil);
-                }
-
-                return;
-            }
-
             dispatch_async(dispatch_get_main_queue(), ^{
-                self.image = image;
+                // check if a latter issued loadInBackground has not replaced the file being loaded
+                if (file == _file) {
+                    self.image = image;
+                }
 
                 if (completion) {
                     completion(image, nil);


### PR DESCRIPTION
The check whether file was changed during loadInBackground call should be on the main thread, not background thread. Otherwise it is possible that file will be changed after the check but before image is actually set. This can cause unsync state, when loadInBackground sets image for wrong file to PFImageView. 

Call to completion handler in this case also should be placed on main thread.