### PR TITLE
Adds missing resources

### DIFF
--- a/ParseUI.podspec
+++ b/ParseUI.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
                           'ParseUI/Classes/Views/*.h',
                           'ParseUI/Classes/Cells/*.h',
                           'ParseUI/Other/*.h'
-  s.resources  = ['ParseUI/Resources/Localization/*.lproj']
+  s.resources  = ['ParseUI/Resources/Localization/*.lproj', 'ParseUI/Resources/Images/*.png', 'ParseUI/Scripts/*.rb']
   s.frameworks          = 'Foundation',
                           'UIKit',
                           'CoreGraphics',


### PR DESCRIPTION
Updates Podspec file to include missing resources. Without these the ruby script cannot run and doesn't generate the `PFResources` files resulting in a broken build.