### PR TITLE
Fixed not set fields when emailAsUsername is set before fields are set.

### DIFF
--- a/ParseUI.xcodeproj/project.pbxproj
+++ b/ParseUI.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		810D6C3119F7F379005B3DB2 /* PFProductTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 810D6C2F19F7F379005B3DB2 /* PFProductTableViewController.m */; };
 		810D6C3419F7F38B005B3DB2 /* PFPurchaseTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 810D6C3219F7F38B005B3DB2 /* PFPurchaseTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		810D6C3519F7F38B005B3DB2 /* PFPurchaseTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 810D6C3319F7F38B005B3DB2 /* PFPurchaseTableViewCell.m */; };
+		811EE7A31B8C17550058B3BE /* PFLogInView_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 811EE7A21B8C17550058B3BE /* PFLogInView_Private.h */; };
 		8129E5F21A9CB067006752BC /* ParseUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2AAC07E0554694100DB518D /* ParseUI.framework */; };
 		8129E5F31A9CB067006752BC /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		8129E5F51A9CB067006752BC /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 81472FA71A1AB37500FD6EED /* Images.xcassets */; };
@@ -151,6 +152,7 @@
 		810D6C3219F7F38B005B3DB2 /* PFPurchaseTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPurchaseTableViewCell.h; sourceTree = "<group>"; };
 		810D6C3319F7F38B005B3DB2 /* PFPurchaseTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPurchaseTableViewCell.m; sourceTree = "<group>"; };
 		811B095A1A0843B9008B3393 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ParseUI/Resources/Info.plist; sourceTree = SOURCE_ROOT; };
+		811EE7A21B8C17550058B3BE /* PFLogInView_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFLogInView_Private.h; sourceTree = "<group>"; };
 		8129E6001A9CB067006752BC /* ParseUIDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParseUIDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8129E6081A9CB1BE006752BC /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8129E6391A9CB320006752BC /* UIDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIDemoViewController.swift; sourceTree = "<group>"; };
@@ -630,6 +632,7 @@
 				81ED075319F68028009745F4 /* PFLogInViewController.h */,
 				81ED075419F68028009745F4 /* PFLogInViewController.m */,
 				81ED075119F68028009745F4 /* PFLogInView.h */,
+				811EE7A21B8C17550058B3BE /* PFLogInView_Private.h */,
 				81ED075219F68028009745F4 /* PFLogInView.m */,
 			);
 			path = LogInViewController;
@@ -751,6 +754,7 @@
 				81E9CD1419F56D6B00487B0F /* ParseUIConstants.h in Headers */,
 				8185BA7C1A642A8B002815C0 /* PFCollectionViewCell.h in Headers */,
 				810D6C1F19F7F006005B3DB2 /* PFImageCache.h in Headers */,
+				811EE7A31B8C17550058B3BE /* PFLogInView_Private.h in Headers */,
 				81E9CD1319F56D6B00487B0F /* ParseUI.h in Headers */,
 				810D6C3419F7F38B005B3DB2 /* PFPurchaseTableViewCell.h in Headers */,
 				81ED079619F6809F009745F4 /* PFImageView.h in Headers */,

--- a/ParseUI/Classes/LogInViewController/PFLogInView.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInView.m
@@ -37,8 +37,9 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
 
 @implementation PFLogInView
 
-#pragma mark -
-#pragma mark Class
+///--------------------------------------
+#pragma mark - Class
+///--------------------------------------
 
 + (PFActionButtonConfiguration *)_defaultSignUpButtonConfiguration {
     PFActionButtonConfiguration *configuration = [[PFActionButtonConfiguration alloc] initWithBackgroundImageColor:[PFColor signupButtonBackgroundColor]
@@ -76,8 +77,9 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
     return configuration;
 }
 
-#pragma mark -
-#pragma mark Init
+///--------------------------------------
+#pragma mark - Init
+///--------------------------------------
 
 - (instancetype)initWithFields:(PFLogInFields)otherFields {
     self = [super initWithFrame:CGRectZero];
@@ -94,67 +96,116 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
     _logo.contentMode = UIViewContentModeScaleAspectFit;
     [self addSubview:_logo];
 
-    if (_fields & PFLogInFieldsDismissButton) {
-        _dismissButton = [[PFDismissButton alloc] initWithFrame:CGRectZero];
-        [self addSubview:_dismissButton];
-    }
-
-    if (_fields & PFLogInFieldsUsernameAndPassword) {
-        _usernameField = [[PFTextField alloc] initWithFrame:CGRectZero
-                                             separatorStyle:(PFTextFieldSeparatorStyleTop |
-                                                             PFTextFieldSeparatorStyleBottom)];
-        _usernameField.autocorrectionType = UITextAutocorrectionTypeNo;
-        _usernameField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        _usernameField.returnKeyType = UIReturnKeyNext;
-        [self addSubview:_usernameField];
-        [self _updateUsernameFieldStyle];
-
-        _passwordField = [[PFTextField alloc] initWithFrame:CGRectZero
-                                             separatorStyle:PFTextFieldSeparatorStyleBottom];
-        _passwordField.placeholder = NSLocalizedString(@"Password", @"Password");
-        _passwordField.secureTextEntry = YES;
-        _passwordField.autocorrectionType = UITextAutocorrectionTypeNo;
-        _passwordField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        _passwordField.returnKeyType = UIReturnKeyDone;
-        [self addSubview:_passwordField];
-    }
-
-    if (_fields & PFLogInFieldsSignUpButton) {
-        _signUpButton = [[PFActionButton alloc] initWithConfiguration:[[self class] _defaultSignUpButtonConfiguration]
-                                                          buttonStyle:PFActionButtonStyleNormal];
-        [self addSubview:_signUpButton];
-    }
-
-    if (_fields & PFLogInFieldsPasswordForgotten) {
-        _passwordForgottenButton = [[PFTextButton alloc] initWithFrame:CGRectZero];
-        [_passwordForgottenButton setTitle:NSLocalizedString(@"Forgot Password?", "Forgot Password?")
-                                  forState:UIControlStateNormal];
-        [self addSubview:_passwordForgottenButton];
-    }
-
-    if (_fields & PFLogInFieldsLogInButton) {
-        _logInButton = [[PFPrimaryButton alloc] initWithBackgroundImageColor:[PFColor loginButtonBackgroundColor]];
-        [_logInButton setTitle:NSLocalizedString(@"Log In", @"Log In") forState:UIControlStateNormal];
-        [self addSubview:_logInButton];
-    }
-
-    if (_fields & PFLogInFieldsFacebook) {
-        _facebookButton = [[PFActionButton alloc] initWithConfiguration:[[self class] _defaultFacebookButtonConfiguration]
-                                                            buttonStyle:PFActionButtonStyleNormal];
-        [self addSubview:_facebookButton];
-    }
-
-    if (_fields & PFLogInFieldsTwitter) {
-        _twitterButton = [[PFActionButton alloc] initWithConfiguration:[[self class] _defaultTwitterButtonConfiguration]
-                                                           buttonStyle:PFActionButtonStyleNormal];
-        [self addSubview:_twitterButton];
-    }
+    [self _updateAllFields];
 
     return self;
 }
 
-#pragma mark -
-#pragma mark UIView
+///--------------------------------------
+#pragma mark - Fields
+///--------------------------------------
+
+- (void)_updateAllFields {
+    if (_fields & PFLogInFieldsDismissButton) {
+        if (!_dismissButton) {
+            _dismissButton = [[PFDismissButton alloc] initWithFrame:CGRectZero];
+            [self addSubview:_dismissButton];
+        }
+    } else {
+        [_dismissButton removeFromSuperview];
+        _dismissButton = nil;
+    }
+
+    if (_fields & PFLogInFieldsUsernameAndPassword) {
+        if (!_usernameField) {
+            _usernameField = [[PFTextField alloc] initWithFrame:CGRectZero
+                                                 separatorStyle:(PFTextFieldSeparatorStyleTop |
+                                                                 PFTextFieldSeparatorStyleBottom)];
+            _usernameField.autocorrectionType = UITextAutocorrectionTypeNo;
+            _usernameField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+            _usernameField.returnKeyType = UIReturnKeyNext;
+            [self addSubview:_usernameField];
+            [self _updateUsernameFieldStyle];
+        }
+
+        if (!_passwordField) {
+            _passwordField = [[PFTextField alloc] initWithFrame:CGRectZero
+                                                 separatorStyle:PFTextFieldSeparatorStyleBottom];
+            _passwordField.placeholder = NSLocalizedString(@"Password", @"Password");
+            _passwordField.secureTextEntry = YES;
+            _passwordField.autocorrectionType = UITextAutocorrectionTypeNo;
+            _passwordField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+            _passwordField.returnKeyType = UIReturnKeyDone;
+            [self addSubview:_passwordField];
+        }
+    } else {
+        [_usernameField removeFromSuperview];
+        _usernameField = nil;
+
+        [_passwordField removeFromSuperview];
+        _passwordField = nil;
+    }
+
+    if (_fields & PFLogInFieldsSignUpButton) {
+        if (!_signUpButton) {
+            _signUpButton = [[PFActionButton alloc] initWithConfiguration:[[self class] _defaultSignUpButtonConfiguration]
+                                                              buttonStyle:PFActionButtonStyleNormal];
+            [self addSubview:_signUpButton];
+        }
+    } else {
+        [_signUpButton removeFromSuperview];
+        _signUpButton = nil;
+    }
+
+    if (_fields & PFLogInFieldsPasswordForgotten) {
+        if (_passwordForgottenButton) {
+            _passwordForgottenButton = [[PFTextButton alloc] initWithFrame:CGRectZero];
+            [_passwordForgottenButton setTitle:NSLocalizedString(@"Forgot Password?", "Forgot Password?")
+                                      forState:UIControlStateNormal];
+            [self addSubview:_passwordForgottenButton];
+        }
+    } else {
+        [_passwordForgottenButton removeFromSuperview];
+        _passwordForgottenButton = nil;
+    }
+
+    if (_fields & PFLogInFieldsLogInButton) {
+        if (!_logInButton) {
+            _logInButton = [[PFPrimaryButton alloc] initWithBackgroundImageColor:[PFColor loginButtonBackgroundColor]];
+            [_logInButton setTitle:NSLocalizedString(@"Log In", @"Log In") forState:UIControlStateNormal];
+            [self addSubview:_logInButton];
+        }
+    } else {
+        [_logInButton removeFromSuperview];
+        _logInButton = nil;
+    }
+
+    if (_fields & PFLogInFieldsFacebook) {
+        if (!_facebookButton) {
+            _facebookButton = [[PFActionButton alloc] initWithConfiguration:[[self class] _defaultFacebookButtonConfiguration]
+                                                                buttonStyle:PFActionButtonStyleNormal];
+            [self addSubview:_facebookButton];
+        }
+    } else {
+        [_facebookButton removeFromSuperview];
+        _facebookButton = nil;
+    }
+
+    if (_fields & PFLogInFieldsTwitter) {
+        if (_twitterButton) {
+            _twitterButton = [[PFActionButton alloc] initWithConfiguration:[[self class] _defaultTwitterButtonConfiguration]
+                                                               buttonStyle:PFActionButtonStyleNormal];
+            [self addSubview:_twitterButton];
+        }
+    } else {
+        [_twitterButton removeFromSuperview];
+        _twitterButton = nil;
+    }
+}
+
+///--------------------------------------
+#pragma mark - UIView
+///--------------------------------------
 
 - (void)layoutSubviews {
     [super layoutSubviews];
@@ -285,8 +336,7 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
     if (_logInButton) {
         CGFloat loginButtonTopInset = floorf(24.0f * contentSizeScale.height);
 
-        CGRect frame = PFRectMakeWithSizeCenteredInRect([_logInButton sizeThatFits:loginContentSize],
-                                                        loginContentRect);;
+        CGRect frame = PFRectMakeWithSizeCenteredInRect([_logInButton sizeThatFits:loginContentSize], loginContentRect);
         frame.origin.y = currentY + loginButtonTopInset;
         _logInButton.frame = frame;
 
@@ -350,9 +400,7 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
 }
 
 - (CGSize)_maxContentSize {
-    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ?
-            CGSizeMake(420.0f, 550.0f) :
-            CGSizeMake(500.0f, 800.0f));
+    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? CGSizeMake(420.0f, 550.0f) : CGSizeMake(500.0f, 800.0f));
 }
 
 - (CGSize)_contentSizeScaleForContentSize:(CGSize)contentSize {
@@ -367,8 +415,17 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
     return contentSizeScale;
 }
 
-#pragma mark -
-#pragma mark Accessors
+///--------------------------------------
+#pragma mark - Accessors
+///--------------------------------------
+
+- (void)setFields:(PFLogInFields)fields {
+    if (_fields != fields) {
+        _fields = fields;
+        [self _updateAllFields];
+        [self setNeedsLayout];
+    }
+}
 
 - (void)setLogo:(UIView *)logo {
     if (self.logo != logo) {
@@ -388,8 +445,9 @@ static NSString *const PFLogInViewDefaultTwitterButtonImageName = @"twitter_icon
     }
 }
 
-#pragma mark -
-#pragma mark Private
+///--------------------------------------
+#pragma mark - Private
+///--------------------------------------
 
 + (void)_validateFields:(PFLogInFields)fields {
     if (fields == PFLogInFieldsNone) {

--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.m
@@ -29,6 +29,7 @@
 #import "PFPrimaryButton.h"
 #import "PFSignUpViewController.h"
 #import "PFTextField.h"
+#import "PFLogInView_Private.h"
 
 NSString *const PFLogInSuccessNotification = @"com.parse.ui.login.success";
 NSString *const PFLogInFailureNotification = @"com.parse.ui.login.failure";
@@ -72,8 +73,9 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
 
 @implementation PFLogInViewController
 
-#pragma mark -
-#pragma mark NSObject
+///--------------------------------------
+#pragma mark - Init
+///--------------------------------------
 
 - (instancetype)init {
     if (self = [super init]) {
@@ -106,17 +108,18 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     }
 }
 
-#pragma mark -
-#pragma mark Dealloc
+///--------------------------------------
+#pragma mark - Dealloc
+///--------------------------------------
 
 - (void)dealloc {
     // Unregister from all notifications
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-
-#pragma mark -
-#pragma mark UIViewController
+///--------------------------------------
+#pragma mark - UIViewController
+///--------------------------------------
 
 - (void)loadView {
     _logInView = [[PFLogInView alloc] initWithFields:_fields];
@@ -143,9 +146,6 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     }
 }
 
-#pragma mark -
-#pragma mark Rotation
-
 - (NSUInteger)supportedInterfaceOrientations {
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         return UIInterfaceOrientationMaskAll;
@@ -154,8 +154,9 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     return UIInterfaceOrientationMaskPortrait;
 }
 
-#pragma mark -
-#pragma mark PFLogInViewController
+///--------------------------------------
+#pragma mark - PFLogInViewController
+///--------------------------------------
 
 - (PFLogInView *)logInView {
     return (PFLogInView *)self.view; // self.view will call loadView if the view is nil
@@ -167,6 +168,17 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
 
 - (BOOL)emailAsUsername {
     return self.logInView.emailAsUsername;
+}
+
+- (void)setFields:(PFLogInFields)fields {
+    if (_fields != fields) {
+        _fields = fields;
+
+        // Avoid force loading logInView
+        if (_logInView) {
+            _logInView.fields = fields;
+        }
+    }
 }
 
 - (void)setDelegate:(id<PFLogInViewControllerDelegate>)delegate {
@@ -185,8 +197,29 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     }
 }
 
-#pragma mark -
-#pragma mark UITextFieldDelegate
+- (PFSignUpViewController *)signUpController {
+    if (!_signUpController) {
+        _signUpController = [[PFSignUpViewController alloc] init];
+        _signUpController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+        _signUpController.emailAsUsername = self.emailAsUsername;
+    }
+    return _signUpController;
+}
+
+- (void)setLoading:(BOOL)loading {
+    if (self.loading != loading) {
+        _loading = loading;
+
+        _logInView.usernameField.enabled = !self.loading;
+        _logInView.passwordField.enabled = !self.loading;
+        _logInView.passwordForgottenButton.enabled = !self.loading;
+        _logInView.dismissButton.enabled = !self.loading;
+    }
+}
+
+///--------------------------------------
+#pragma mark - UITextFieldDelegate
+///--------------------------------------
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
     if (textField == _logInView.usernameField) {
@@ -200,8 +233,9 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     return YES;
 }
 
-#pragma mark -
-#pragma mark UIAlertViewDelegate
+///--------------------------------------
+#pragma mark - UIAlertViewDelegate
+///--------------------------------------
 
 - (void)alertView:(UIAlertView *)alertView willDismissWithButtonIndex:(NSInteger)buttonIndex {
     if (buttonIndex != [alertView cancelButtonIndex]) {
@@ -210,8 +244,9 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     }
 }
 
-#pragma mark -
-#pragma mark Private
+///--------------------------------------
+#pragma mark - Private
+///--------------------------------------
 
 - (void)setupHandlers {
     [_logInView.dismissButton addTarget:self
@@ -455,31 +490,9 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     [[NSNotificationCenter defaultCenter] postNotificationName:PFLogInCancelNotification object:self];
 }
 
-#pragma mark -
-#pragma mark Accessors
-
-- (PFSignUpViewController *)signUpController {
-    if (!_signUpController) {
-        _signUpController = [[PFSignUpViewController alloc] init];
-        _signUpController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-        _signUpController.emailAsUsername = self.emailAsUsername;
-    }
-    return _signUpController;
-}
-
-- (void)setLoading:(BOOL)loading {
-    if (self.loading != loading) {
-        _loading = loading;
-
-        _logInView.usernameField.enabled = !self.loading;
-        _logInView.passwordField.enabled = !self.loading;
-        _logInView.passwordForgottenButton.enabled = !self.loading;
-        _logInView.dismissButton.enabled = !self.loading;
-    }
-}
-
-#pragma mark -
-#pragma mark Keyboard
+///--------------------------------------
+#pragma mark - Keyboard
+///--------------------------------------
 
 - (UIView *)currentFirstResponder {
     if ([_logInView.usernameField isFirstResponder]) {
@@ -502,7 +515,8 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(_keyboardWillHide:)
-                                                 name:UIKeyboardWillHideNotification object:nil];
+                                                 name:UIKeyboardWillHideNotification
+                                               object:nil];
 }
 
 - (void)_keyboardWillShow:(NSNotification *)notification {
@@ -578,8 +592,7 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
             return; // No scrolling required
         }
 
-        contentOffset = CGPointMake(0.0f, MIN(offsetForScrollingTextFieldToTop,
-                                              offsetForScrollingLowestViewToBottom));
+        contentOffset = CGPointMake(0.0f, MIN(offsetForScrollingTextFieldToTop, offsetForScrollingLowestViewToBottom));
     }
 
     [_logInView setContentOffset:contentOffset animated:animated];

--- a/ParseUI/Classes/LogInViewController/PFLogInView_Private.h
+++ b/ParseUI/Classes/LogInViewController/PFLogInView_Private.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2014, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ *  copy, modify, and distribute this software in source code or binary form for use
+ *  in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#import <ParseUI/PFLogInView.h>
+
+@interface PFLogInView (Private)
+
+@property (nonatomic, assign, readwrite) PFLogInFields fields;
+
+@end


### PR DESCRIPTION
- Made `fields` property PFLogInView be readwrite, but only privately, which ultimately resolved the bug
- Made `fields` property on PFLogInViewController change `fields` of PFLogInView, which makes it work as expected.

Fixes #130 