### PR TITLE
Trim email of whitespace when signing up.

### DIFF
--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
@@ -248,6 +248,8 @@ static NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"addit
     NSString *username = _signUpView.usernameField.text ?: @"";
     NSString *password = _signUpView.passwordField.text ?: @"";
     NSString *email = (self.emailAsUsername ? username : _signUpView.emailField.text);
+    email = [email stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
     NSString *additional = _signUpView.additionalField.text;
 
     NSMutableDictionary *dictionary = [@{ PFSignUpViewControllerDelegateInfoUsernameKey : username,


### PR DESCRIPTION
Since this is email field - you can't really end or start it with whitespace - so trim every whitespace and newline from it on signup.