### PR TITLE
When comparing the size of the image and the imageview's size. The origin of the image view should not be considered.

### DIFF
--- a/ParseUI/Classes/Cells/PFCollectionViewCell.m
+++ b/ParseUI/Classes/Cells/PFCollectionViewCell.m
@@ -56,7 +56,7 @@
 
     // Adapt content mode of _imageView to fit the image in bounds if the layout frame is smaller or center if it's bigger.
     if (!CGRectIsEmpty(imageViewFrame)) {
-        if (CGRectContainsRect(PFRectMakeWithSize(_imageView.image.size), imageViewFrame)) {
+        if (CGRectContainsRect(PFRectMakeWithSize(_imageView.image.size), PFRectMakeWithSize(imageViewFrame.size))) {
             _imageView.contentMode = UIViewContentModeScaleAspectFit;
         } else {
             _imageView.contentMode = UIViewContentModeCenter;


### PR DESCRIPTION
I have noticed that when positioning a imageView in a cell on another location unintended behavior occurs due to the fact that even though the image could be contained within the bounds of the imageview, the CGContainsRect call "fails" because the origin places one or more corners of the imageview frame outside of the generated imageView rect.