### PR TITLE
Fixed localization not working when installed as a dynamic framework.

### DIFF
--- a/ParseUI/Classes/Internal/PFLocalization.h
+++ b/ParseUI/Classes/Internal/PFLocalization.h
@@ -24,6 +24,6 @@
 
 #undef NSLocalizedString
 #define NSLocalizedString(key, comment) \
-[[NSBundle mainBundle] localizedStringForKey:key value:nil table:@"ParseUI"]
+[[NSBundle bundleForClass:[self class]] localizedStringForKey:key value:nil table:@"ParseUI"]
 
 #endif


### PR DESCRIPTION
Use `bundleForClass:` since it's going to be different when loaded as a dynamic framework.
Fixes #136