### PR TITLE
Make ParseUI fully compile from source for app extensions.

### DIFF
--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.m
@@ -288,7 +288,7 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)_forgotPasswordAction {
+- (void)_forgotPasswordAction PF_EXTENSION_UNAVAILABLE("") {
     NSString *title = NSLocalizedString(@"Reset Password", @"Forgot password request title in PFLogInViewController");
     NSString *message = NSLocalizedString(@"Please enter the email address for your account.",
                                           @"Email request message in PFLogInViewController");

--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
@@ -399,11 +399,13 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
 
         [self presentViewController:errorController animated:YES completion:nil];
     } else {
-        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Error", @"Error")
-                                                            message:errorMessage
-                                                           delegate:nil
-                                                  cancelButtonTitle:NSLocalizedString(@"OK", @"OK")
-                                                  otherButtonTitles:nil];
+        // Cast to `id` is required for building succesfully for app extensions,
+        // this code actually never runs in App Extensions, since they are iOS 8.0+, so we are good with just a hack
+        UIAlertView *alertView = [(id)[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Error", @"Error")
+                                                                message:errorMessage
+                                                               delegate:nil
+                                                      cancelButtonTitle:NSLocalizedString(@"OK", @"OK")
+                                                      otherButtonTitles:nil];
 
         [alertView show];
     }

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -398,7 +398,7 @@
     }
 
     [[BFTask taskForCompletionOfAllTasks:allDeletionTasks]
-                       continueWithBlock:deletionHandlerBlock];
+     continueWithBlock:deletionHandlerBlock];
 }
 
 - (PFTableViewCell *)tableView:(UITableView *)otherTableView cellForNextPageAtIndexPath:(NSIndexPath *)indexPath {
@@ -531,11 +531,13 @@
 
         [self presentViewController:errorController animated:YES completion:nil];
     } else {
-        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Error", @"Error")
-                                                            message:errorMessage
-                                                           delegate:nil
-                                                  cancelButtonTitle:NSLocalizedString(@"OK", @"OK")
-                                                  otherButtonTitles:nil];
+        // Cast to `id` is required for building succesfully for app extensions,
+        // this code actually never runs in App Extensions, since they are iOS 8.0+, so we are good with just a hack
+        UIAlertView *alertView = [(id)[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Error", @"Error")
+                                                                message:errorMessage
+                                                               delegate:nil
+                                                      cancelButtonTitle:NSLocalizedString(@"OK", @"OK")
+                                                      otherButtonTitles:nil];
 
         [alertView show];
     }


### PR DESCRIPTION
Do some hacks to make sure the code paths for app extensions are never actually invoked.
Fixes #144