### PR TITLE
Update to UIAlertController

### DIFF
--- a/ParseUI/Classes/Internal/Extensions/PFUIAlertController.h
+++ b/ParseUI/Classes/Internal/Extensions/PFUIAlertController.h
@@ -21,14 +21,19 @@
 
 #import <UIKit/UIKit.h>
 
-@interface PFUIAlertView : UIAlertView
+@interface PFUIAlertController : UIAlertController
 
-+ (void)showAlertViewWithTitle:(NSString *)title
-                         error:(NSError *)error;
-+ (void)showAlertViewWithTitle:(NSString *)title
-                       message:(NSString *)message;
-+ (void)showAlertViewWithTitle:(NSString *)title
-                       message:(NSString *)message
-             cancelButtonTitle:(NSString *)cancelButtonTitle;
++ (void)showAlertControllerWithTitle:(NSString *)title
+                               error:(NSError *)error
+                    onViewController:(UIViewController *)viewController;
+
++ (void)showAlertControllerWithTitle:(NSString *)title
+                             message:(NSString *)message
+                    onViewController:(UIViewController *)viewController;
+
++ (void)showAlertControllerWithTitle:(NSString *)title
+                             message:(NSString *)message
+                   cancelButtonTitle:(NSString *)cancelButtonTitle
+                    onViewController:(UIViewController *)viewController;
 
 @end

--- a/ParseUI/Classes/Internal/Extensions/PFUIAlertController.m
+++ b/ParseUI/Classes/Internal/Extensions/PFUIAlertController.m
@@ -19,13 +19,13 @@
  *
  */
 
-#import "PFUIAlertView.h"
+#import "PFUIAlertController.h"
 
 #import "PFLocalization.h"
 
-@implementation PFUIAlertView
+@implementation PFUIAlertController
 
-+ (void)showAlertViewWithTitle:(NSString *)title error:(NSError *)error {
++ (void)showAlertControllerWithTitle:(NSString *)title error:(NSError *)error onViewController:(UIViewController *)viewController {
     NSString *message = error.userInfo[@"error"];
     if (!message) {
       message = [error.userInfo[@"originalError"] localizedDescription];
@@ -33,24 +33,29 @@
     if (!message) {
       message = [error localizedDescription];      
     }
-    [self showAlertViewWithTitle:title message:message];
+    [self showAlertControllerWithTitle:title message:message onViewController:viewController];
 }
 
-+ (void)showAlertViewWithTitle:(NSString *)title message:(NSString *)message {
-    [self showAlertViewWithTitle:title
++ (void)showAlertControllerWithTitle:(NSString *)title message:(NSString *)message onViewController:(UIViewController *)viewController {
+    [self showAlertControllerWithTitle:title
                          message:message
-               cancelButtonTitle:NSLocalizedString(@"OK", @"OK")];
+               cancelButtonTitle:NSLocalizedString(@"OK", @"OK")
+                onViewController:viewController];
 }
 
-+ (void)showAlertViewWithTitle:(NSString *)title
++ (void)showAlertControllerWithTitle:(NSString *)title
                        message:(NSString *)message
-             cancelButtonTitle:(NSString *)cancelButtonTitle {
-    UIAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                                delegate:nil
-                                       cancelButtonTitle:cancelButtonTitle
-                                       otherButtonTitles:nil];
-    [alertView show];
+             cancelButtonTitle:(NSString *)cancelButtonTitle
+              onViewController:(UIViewController *)viewController {
+    UIAlertController *controller = [self alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [viewController dismissViewControllerAnimated:YES completion:nil];
+    }];
+    
+    [controller addAction:cancelAction];
+    
+    [viewController presentViewController:controller animated:YES completion:nil];
 }
 
 @end

--- a/ParseUI/Classes/ProductTableViewController/PFProductTableViewController.m
+++ b/ParseUI/Classes/ProductTableViewController/PFProductTableViewController.m
@@ -25,7 +25,7 @@
 #import <Parse/PFPurchase.h>
 #import <Parse/PFQuery.h>
 
-#import "PFUIAlertView.h"
+#import "PFUIAlertController.h"
 #import "PFLocalization.h"
 #import "PFPurchaseTableViewCell.h"
 
@@ -96,7 +96,7 @@ static NSString *const PFProductMetadataPriceLocaleKey = @"priceLocale";
 
                                                  NSString *title = NSLocalizedString(@"Download Error",
                                                                                      @"Download Error");
-                                                 [PFUIAlertView showAlertViewWithTitle:title error:downloadError];
+                                                 [PFUIAlertController showAlertControllerWithTitle:title error:downloadError onViewController:self];
                                              }
                                          }
                                            progress:^(int percentDone) {
@@ -175,7 +175,7 @@ static NSString *const PFProductMetadataPriceLocaleKey = @"priceLocale";
         [PFPurchase buyProduct:product.productIdentifier block:^(NSError *error) {
             if (error) {
                 NSString *title = NSLocalizedString(@"Purchase Error", @"Purchase Error");
-                [PFUIAlertView showAlertViewWithTitle:title error:error];
+                [PFUIAlertController showAlertControllerWithTitle:title error:error onViewController:self];
             }
         }];
     }

--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
@@ -31,6 +31,7 @@
 #import "PFImageView.h"
 #import "PFLoadingView.h"
 #import "PFLocalization.h"
+#import "PFUIAlertController.h"
 
 static NSString *const PFQueryCollectionViewCellIdentifier = @"cell";
 static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"nextPageView";
@@ -393,15 +394,7 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
                               error.localizedDescription];
 
     if ([UIAlertController class]) {
-        UIAlertController *errorController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Error", @"Error")
-                                                                                 message:errorMessage
-                                                                          preferredStyle:UIAlertControllerStyleAlert];
-
-        [errorController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", @"OK")
-                                                            style:UIAlertActionStyleCancel
-                                                          handler:nil]];
-
-        [self presentViewController:errorController animated:YES completion:nil];
+        [PFUIAlertController showAlertControllerWithTitle:NSLocalizedString(@"Error", @"Error") message:errorMessage onViewController:self];
     } else {
         // Cast to `id` is required for building succesfully for app extensions,
         // this code actually never runs in App Extensions, since they are iOS 8.0+, so we are good with just a hack

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -31,6 +31,7 @@
 #import "PFLoadingView.h"
 #import "PFLocalization.h"
 #import "PFTableViewCell.h"
+#import "PFUIAlertController.h"
 
 // Add headers to kill any warnings.
 // `initWithStyle:` is a UITableViewController method.
@@ -521,15 +522,7 @@
                               error.localizedDescription];
 
     if ([UIAlertController class]) {
-        UIAlertController *errorController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Error", @"Error")
-                                                                                 message:errorMessage
-                                                                          preferredStyle:UIAlertControllerStyleAlert];
-
-        [errorController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", @"OK")
-                                                            style:UIAlertActionStyleCancel
-                                                          handler:nil]];
-
-        [self presentViewController:errorController animated:YES completion:nil];
+        [PFUIAlertController showAlertControllerWithTitle:NSLocalizedString(@"Error", @"Error") message:errorMessage onViewController:self];
     } else {
         // Cast to `id` is required for building succesfully for app extensions,
         // this code actually never runs in App Extensions, since they are iOS 8.0+, so we are good with just a hack

--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
@@ -24,7 +24,7 @@
 #import <Parse/PFConstants.h>
 #import <Parse/PFUser.h>
 
-#import "PFUIAlertView.h"
+#import "PFUIAlertController.h"
 #import "PFLocalization.h"
 #import "PFPrimaryButton.h"
 #import "PFTextField.h"
@@ -362,7 +362,7 @@ static NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"addit
         }
 
         if (message != nil) {
-            [PFUIAlertView showAlertViewWithTitle:title message:message];
+            [PFUIAlertController showAlertControllerWithTitle:title message:message onViewController:self];
             [responder becomeFirstResponder];
 
             return;
@@ -370,7 +370,7 @@ static NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"addit
     }
 
     // Show the generic error alert, as no custom cases matched before
-    [PFUIAlertView showAlertViewWithTitle:title error:error];
+    [PFUIAlertController showAlertControllerWithTitle:title error:error onViewController:self];
 }
 
 - (void)_cancelSignUp {


### PR DESCRIPTION
fixes #172

Was unsure about the uses of UIAlertView in `PFQueryTableViewController` and `PFQueryCollectionViewController` inside the `_handleDeletionError` method : 

```objective-c
// Cast to `id` is required for building succesfully for app extensions,
// this code actually never runs in App Extensions, since they are iOS 8.0+, so we are good with just a hack
UIAlertView *alertView = [(id)[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Error", @"Error")
                                                        message:errorMessage
                                                       delegate:nil
                                              cancelButtonTitle:NSLocalizedString(@"OK", @"OK")
                                              otherButtonTitles:nil];

[alertView show];
```

If it can be replaced with a `UIAlertController`, I will do so.