### PR TITLE
Use non-nil facebook permissions by default in PFLogInViewController.

### DIFF
--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.m
@@ -103,6 +103,8 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
     self.modalPresentationStyle = UIModalPresentationFormSheet;
     _fields = PFLogInFieldsDefault;
 
+    _facebookPermissions = @[ @"public_profile" ];
+
     if ([self respondsToSelector:@selector(automaticallyAdjustsScrollViewInsets)]) {
         self.automaticallyAdjustsScrollViewInsets = NO;
     }


### PR DESCRIPTION
Workaround and double-guard for an issue inside FBSDK.
Fixes #203.