### PR TITLE
Methods to reflect data changes you've made by other means

### DIFF
--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -185,32 +185,24 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @abstract Reflects that there's been a change in the results of `queryForTable` and there is about to be a change in `tableView` as rendered, such that the object at `_mutableObjects[indexPathSource.row]` must be moved to `_mutableObjects[indexPathDestination.row]`.
  */
-- (void)willMoveRowFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination;
+- (void)willMoveRowForObjectFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination;
 
 /*!
  @abstract Reflects that there's been a change in the results of `queryForTable`, such that `tableView` as rendered must change -- specifically, the object at `indexPathSource` must now appear at `indexPathDestination` -- and the object at `_mutableObjects[indexPathSource.row]` must be moved to `_mutableObjects[indexPathDestination.row]`
  */
-- (void)moveRowFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination;
-
-/*!
- @abstract Reflects that there's been a change in the results of `queryForTable` and there is about to be a change in `tableView` as rendered, such that `_mutableObjects` must have `object` inserted at `indexPath.row`.
- */
-- (void)willInsertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath;
+- (void)moveRowForObjectFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination;
 
 /*!
  @abstract Reflects that there's been a change in the results of `queryForTable`, so that `tableView` as rendered must change -- specifically, `object` must be inserted at `indexPath` -- and `_mutableObjects` must have `object` inserted at `indexPath.row`.
  */
-- (void)insertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
-
-/*!
- @abstract Reflects that there's been a change in the results of `queryForTable` and there is about to be a change in `tableView` as rendered, such that the object at `_mutableObjects[indexPathSource.row]` must be moved to `_mutableObjects[indexPathDestination.row]`.
- */
-- (void)willDeleteRowAtIndexPath:(NSIndexPath *)indexPath;
+- (void)insertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)insertRowsForObjects:(NSArray *)objects atIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
 
 /*!
  @abstract Reflects that there's been a change in the results of `queryForTable`, so that `tableView` as rendered must change -- specifically, the row at `indexPath` must be deleted -- and `_mutableObjects[indexPath.row]` must be removed.
  */
-- (void)deleteRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
+- (void)deleteRowForObjectAtIndexPath:(NSIndexPath *)indexPath withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)deleteRowsForObjectsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
 
 /*!
  @abstract Clears the table of all objects.

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.h
@@ -183,6 +183,36 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeObjectsAtIndexPaths:(nullable NSArray *)indexes animated:(BOOL)animated;
 
 /*!
+ @abstract Reflects that there's been a change in the results of `queryForTable` and there is about to be a change in `tableView` as rendered, such that the object at `_mutableObjects[indexPathSource.row]` must be moved to `_mutableObjects[indexPathDestination.row]`.
+ */
+- (void)willMoveRowFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination;
+
+/*!
+ @abstract Reflects that there's been a change in the results of `queryForTable`, such that `tableView` as rendered must change -- specifically, the object at `indexPathSource` must now appear at `indexPathDestination` -- and the object at `_mutableObjects[indexPathSource.row]` must be moved to `_mutableObjects[indexPathDestination.row]`
+ */
+- (void)moveRowFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination;
+
+/*!
+ @abstract Reflects that there's been a change in the results of `queryForTable` and there is about to be a change in `tableView` as rendered, such that `_mutableObjects` must have `object` inserted at `indexPath.row`.
+ */
+- (void)willInsertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath;
+
+/*!
+ @abstract Reflects that there's been a change in the results of `queryForTable`, so that `tableView` as rendered must change -- specifically, `object` must be inserted at `indexPath` -- and `_mutableObjects` must have `object` inserted at `indexPath.row`.
+ */
+- (void)insertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
+
+/*!
+ @abstract Reflects that there's been a change in the results of `queryForTable` and there is about to be a change in `tableView` as rendered, such that the object at `_mutableObjects[indexPathSource.row]` must be moved to `_mutableObjects[indexPathDestination.row]`.
+ */
+- (void)willDeleteRowAtIndexPath:(NSIndexPath *)indexPath;
+
+/*!
+ @abstract Reflects that there's been a change in the results of `queryForTable`, so that `tableView` as rendered must change -- specifically, the row at `indexPath` must be deleted -- and `_mutableObjects[indexPath.row]` must be removed.
+ */
+- (void)deleteRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
+
+/*!
  @abstract Clears the table of all objects.
  */
 - (void)clear;

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -442,7 +442,13 @@
 }
 - (void)insertRowsForObjects:(NSArray *)objects atIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
     
-    [_mutableObjects addObjectsFromArray:objects];
+    NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
+    for (int i = 0; i < [indexPaths count]; i++) {
+        NSIndexPath *indexPath = indexPaths[i];
+        [indexes addIndex:indexPath.row];
+    }
+
+    [_mutableObjects insertObjects:objects atIndexes:indexes];
     [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:animation];
 }
 

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -423,40 +423,42 @@
 }
 
 
-- (void)willMoveRowFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination {
+- (void)willMoveRowForObjectFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination {
     [self validateIndexPathsForMovingObject:@[indexPathSource, indexPathDestination]];
     
     PFObject *obj = [_mutableObjects objectAtIndex:indexPathSource.row];
     [_mutableObjects removeObjectAtIndex:indexPathSource.row];
     [_mutableObjects insertObject:obj atIndex:indexPathDestination.row];
 }
-- (void)moveRowFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination {
-    [self willMoveRowFromIndexPath:indexPathSource toIndexPath:indexPathDestination];
+
+- (void)moveRowForObjectFromIndexPath:(NSIndexPath *)indexPathSource toIndexPath:(NSIndexPath *)indexPathDestination {
+    [self willMoveRowForObjectFromIndexPath:indexPathSource toIndexPath:indexPathDestination];
     [self.tableView moveRowAtIndexPath:indexPathSource toIndexPath:indexPathDestination];
 }
 
 
-- (void)willInsertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath {
-    [self validateIndexPathForAddingObject:indexPath];
-
-    [_mutableObjects insertObject:object atIndex:indexPath.row];
+- (void)insertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath withRowAnimation:(UITableViewRowAnimation)animation {
+    [self insertRowsForObjects:@[object] atIndexPaths:@[indexPath] withRowAnimation:animation];
 }
-- (void)insertRowForObject:(PFObject *)object atIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
-    [self willInsertRowForObject:object atIndexPath:indexPath];
-    UITableViewRowAnimation anim = animated ? UITableViewRowAnimationLeft : UITableViewRowAnimationNone;
-    [self.tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:anim];
-}
-
-
-- (void)willDeleteRowAtIndexPath:(NSIndexPath *)indexPath {
-    [self validateIndexPathsForMovingObject:@[indexPath]];
+- (void)insertRowsForObjects:(NSArray *)objects atIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
     
-    [_mutableObjects removeObjectAtIndex:indexPath.row];
+    [_mutableObjects addObjectsFromArray:objects];
+    [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:animation];
 }
-- (void)deleteRowAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
-    [self willDeleteRowAtIndexPath:indexPath];
-    UITableViewRowAnimation anim = animated ? UITableViewRowAnimationLeft : UITableViewRowAnimationNone;
-    [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:anim];
+
+- (void)deleteRowForObjectAtIndexPath:(NSIndexPath *)indexPath withRowAnimation:(UITableViewRowAnimation)animation {
+    [self deleteRowsForObjectsAtIndexPaths:@[indexPath] withRowAnimation:animation];
+}
+
+- (void)deleteRowsForObjectsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
+    NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
+    for (int i = 0; i < [indexPaths count]; i++) {
+        NSIndexPath *indexPath = indexPaths[i];
+        [indexes addIndex:indexPath.row];
+    }
+    
+    [_mutableObjects removeObjectsAtIndexes:indexes];
+    [self.tableView deleteRowsAtIndexPaths:indexPaths withRowAnimation:animation];
 }
 
 


### PR DESCRIPTION
For use when you want a `PFQueryTableViewController` to reflect a change in your data (that is, a change in the results of its `queryForTable`) without calling `loadObjects` (which you don't want to do if you prefer not to reload the whole table).
