### PR TITLE
Fix never succesfully completed task of -loadObjects in Query/Collection View Controllers.

### DIFF
--- a/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
+++ b/ParseUI/Classes/QueryCollectionViewController/PFQueryCollectionViewController.m
@@ -234,10 +234,10 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
     self.loading = YES;
     [self objectsWillLoad];
 
-    BFTaskCompletionSource *source = [BFTaskCompletionSource taskCompletionSource];
-
     PFQuery *query = [self queryForCollection];
     [self _alterQuery:query forLoadingPage:page];
+
+    BFTaskCompletionSource PF_GENERIC(NSArray<__kindof PFObject *>*)*source = [BFTaskCompletionSource taskCompletionSource];
     [query findObjectsInBackgroundWithBlock:^(NSArray *foundObjects, NSError *error) {
         if (![Parse isLocalDatastoreEnabled] &&
             query.cachePolicy != kPFCachePolicyCacheOnly &&
@@ -266,9 +266,12 @@ static NSString *const PFQueryCollectionViewNextPageReusableViewIdentifier = @"n
         [self objectsDidLoad:error];
         [self.refreshControl endRefreshing];
 
-        [source setError:error];
+        if (error) {
+            [source trySetError:error];
+        } else {
+            [source trySetResult:foundObjects];
+        }
     }];
-
     return source.task;
 }
 

--- a/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
+++ b/ParseUI/Classes/QueryTableViewController/PFQueryTableViewController.m
@@ -220,10 +220,10 @@
     self.loading = YES;
     [self objectsWillLoad];
 
-    BFTaskCompletionSource *source = [BFTaskCompletionSource taskCompletionSource];
-
     PFQuery *query = [self queryForTable];
     [self _alterQuery:query forLoadingPage:page];
+
+    BFTaskCompletionSource PF_GENERIC(NSArray<__kindof PFObject *>*)*source = [BFTaskCompletionSource taskCompletionSource];
     [query findObjectsInBackgroundWithBlock:^(NSArray *foundObjects, NSError *error) {
         if (![Parse isLocalDatastoreEnabled] &&
             query.cachePolicy != kPFCachePolicyCacheOnly &&
@@ -252,7 +252,11 @@
         [self objectsDidLoad:error];
         [self.refreshControl endRefreshing];
 
-        [source setError:error];
+        if (error) {
+            [source trySetError:error];
+        } else {
+            [source trySetResult:foundObjects];
+        }
     }];
 
     return source.task;


### PR DESCRIPTION
We are always completing this with an error (either full or `nil` one) - which is quite wrong.