### PR TITLE
Custom UI: Allow to use custom nib for login & sign up controller

### DIFF
--- a/ParseUI/Classes/LogInViewController/PFLogInView.h
+++ b/ParseUI/Classes/LogInViewController/PFLogInView.h
@@ -125,47 +125,47 @@ extern NSString *const PFLogInViewDismissButtonAccessibilityIdentifier;
 /**
  The bitmask which specifies the enabled log in elements in the view.
  */
-@property (nonatomic, assign, readonly) PFLogInFields fields;
+@property (nonatomic, assign) PFLogInFields fields;
 
 /**
  The username text field. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) PFTextField *usernameField;
+@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *usernameField;
 
 /**
  The password text field. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) PFTextField *passwordField;
+@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *passwordField;
 
 /**
  The password forgotten button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *passwordForgottenButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *passwordForgottenButton;
 
 /**
  The log in button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *logInButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *logInButton;
 
 /**
  The Facebook button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *facebookButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *facebookButton;
 
 /**
  The Twitter button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *twitterButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *twitterButton;
 
 /**
  The sign up button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *signUpButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *signUpButton;
 
 /**
  It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *dismissButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *dismissButton;
 
 /**
  The facebook/twitter login label.

--- a/ParseUI/Classes/LogInViewController/PFLogInView.h
+++ b/ParseUI/Classes/LogInViewController/PFLogInView.h
@@ -130,42 +130,42 @@ extern NSString *const PFLogInViewDismissButtonAccessibilityIdentifier;
 /**
  The username text field. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *usernameField;
+@property (nullable, nonatomic, strong) IBOutlet PFTextField *usernameField;
 
 /**
  The password text field. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *passwordField;
+@property (nullable, nonatomic, strong) IBOutlet PFTextField *passwordField;
 
 /**
  The password forgotten button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *passwordForgottenButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *passwordForgottenButton;
 
 /**
  The log in button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *logInButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *logInButton;
 
 /**
  The Facebook button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *facebookButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *facebookButton;
 
 /**
  The Twitter button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *twitterButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *twitterButton;
 
 /**
  The sign up button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *signUpButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *signUpButton;
 
 /**
  It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *dismissButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *dismissButton;
 
 /**
  The facebook/twitter login label.

--- a/ParseUI/Classes/LogInViewController/PFLogInView.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInView.m
@@ -48,6 +48,17 @@ NSString *const PFLogInViewTwitterButtonAccessibilityIdentifier = @"PFLogInViewT
 NSString *const PFLogInViewFacebookButtonAccessibilityIdentifier = @"PFLogInViewFacebookButtonAccessibilityIdentifier";
 NSString *const PFLogInViewDismissButtonAccessibilityIdentifier = @"PFLogInViewDismissButtonAccessibilityIdentifier";
 
+///--------------------------------------
+#pragma mark - Interface
+///--------------------------------------
+
+@interface PFLogInView()
+
+/// Whether view have been loaded from nib or not
+@property (nonatomic, assign) BOOL loadedFromNib;
+
+@end
+
 @implementation PFLogInView
 
 ///--------------------------------------
@@ -112,6 +123,13 @@ NSString *const PFLogInViewDismissButtonAccessibilityIdentifier = @"PFLogInViewD
     [self _updateAllFields];
 
     return self;
+}
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+
+    // remember view have been loaded from nib
+    self.loadedFromNib = YES;
 }
 
 ///--------------------------------------
@@ -230,6 +248,11 @@ NSString *const PFLogInViewDismissButtonAccessibilityIdentifier = @"PFLogInViewD
 
 - (void)layoutSubviews {
     [super layoutSubviews];
+
+    // don't layout field if view is loaded from nib
+    if(self.loadedFromNib) {
+        return;
+    }
 
     const CGRect bounds = PFRectMakeWithOriginSize(CGPointZero, self.bounds.size);
 

--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.h
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.h
@@ -56,6 +56,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, strong, readonly) PFLogInView *logInView;
 
+
+/**
+ A bool specifying whether the view should be loaded from a custom nib.
+
+ @see PFLogInView
+ */
+@property (nonatomic, assign) BOOL useCustomNib;
+
 ///--------------------------------------
 /// @name Configuring Log In Behaviors
 ///--------------------------------------

--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.m
@@ -126,7 +126,7 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
 - (void)loadView {
     if(self.useCustomNib) {
         [super loadView];
-        _logInView = self.view;
+        _logInView = (PFLogInView *) self.view;
     } else {
         _logInView = [[PFLogInView alloc] initWithFields:_fields];
     }

--- a/ParseUI/Classes/LogInViewController/PFLogInViewController.m
+++ b/ParseUI/Classes/LogInViewController/PFLogInViewController.m
@@ -124,7 +124,12 @@ NSString *const PFLogInCancelNotification = @"com.parse.ui.login.cancel";
 ///--------------------------------------
 
 - (void)loadView {
-    _logInView = [[PFLogInView alloc] initWithFields:_fields];
+    if(self.useCustomNib) {
+        [super loadView];
+        _logInView = self.view;
+    } else {
+        _logInView = [[PFLogInView alloc] initWithFields:_fields];
+    }
     [_logInView setPresentingViewController:self];
 
     UITapGestureRecognizer *gestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(_dismissKeyboard)];

--- a/ParseUI/Classes/SignUpViewController/PFSignUpView.h
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpView.h
@@ -122,34 +122,34 @@ extern NSString *const PFSignUpViewDismissButtonAccessibilityIdentifier;
 /**
  The username text field.
  */
-@property (nullable, nonatomic, strong, readonly) PFTextField *usernameField;
+@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *usernameField;
 
 /**
  The password text field.
  */
-@property (nullable, nonatomic, strong, readonly) PFTextField *passwordField;
+@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *passwordField;
 
 /**
  The email text field. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) PFTextField *emailField;
+@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *emailField;
 
 /**
  The additional text field. It is `nil` if the element is not enabled.
 
  This field is intended to be customized.
  */
-@property (nullable, nonatomic, strong, readonly) PFTextField *additionalField;
+@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *additionalField;
 
 /**
  The sign up button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *signUpButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *signUpButton;
 
 /**
  The dismiss button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) UIButton *dismissButton;
+@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *dismissButton;
 
 @end
 

--- a/ParseUI/Classes/SignUpViewController/PFSignUpView.h
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpView.h
@@ -122,34 +122,34 @@ extern NSString *const PFSignUpViewDismissButtonAccessibilityIdentifier;
 /**
  The username text field.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *usernameField;
+@property (nullable, nonatomic, strong) IBOutlet PFTextField *usernameField;
 
 /**
  The password text field.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *passwordField;
+@property (nullable, nonatomic, strong) IBOutlet PFTextField *passwordField;
 
 /**
  The email text field. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *emailField;
+@property (nullable, nonatomic, strong) IBOutlet PFTextField *emailField;
 
 /**
  The additional text field. It is `nil` if the element is not enabled.
 
  This field is intended to be customized.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet PFTextField *additionalField;
+@property (nullable, nonatomic, strong) IBOutlet PFTextField *additionalField;
 
 /**
  The sign up button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *signUpButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *signUpButton;
 
 /**
  The dismiss button. It is `nil` if the element is not enabled.
  */
-@property (nullable, nonatomic, strong, readonly) IBOutlet UIButton *dismissButton;
+@property (nullable, nonatomic, strong) IBOutlet UIButton *dismissButton;
 
 @end
 

--- a/ParseUI/Classes/SignUpViewController/PFSignUpView.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpView.m
@@ -43,6 +43,22 @@ NSString *const PFSignUpViewAdditionalFieldAccessibilityIdentifier = @"PFSignUpV
 NSString *const PFSignUpViewSignUpButtonAccessibilityIdentifier = @"PFSignUpViewSignUpButtonAccessibilityIdentifier";
 NSString *const PFSignUpViewDismissButtonAccessibilityIdentifier = @"PFSignUpViewDismissButtonAccessibilityIdentifier";
 
+///--------------------------------------
+#pragma mark - Interface
+///--------------------------------------
+
+@interface PFSignUpView()
+
+/// Whether view have been loaded from nib or not
+@property (nonatomic, assign) BOOL loadedFromNib;
+
+@end
+
+
+///--------------------------------------
+#pragma mark - Class
+///--------------------------------------
+
 @implementation PFSignUpView
 
 #pragma mark -
@@ -128,11 +144,23 @@ NSString *const PFSignUpViewDismissButtonAccessibilityIdentifier = @"PFSignUpVie
     return self;
 }
 
+- (void)awakeFromNib {
+    [super awakeFromNib];
+
+    // remember view have been loaded from nib
+    self.loadedFromNib = YES;
+}
+
 #pragma mark -
 #pragma mark UIView
 
 - (void)layoutSubviews {
     [super layoutSubviews];
+
+    // don't layout field if view is loaded from nib
+    if(self.loadedFromNib) {
+        return;
+    }
 
     CGRect bounds = self.bounds;
 

--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.h
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.h
@@ -55,6 +55,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, strong, readonly) PFSignUpView *signUpView;
 
+/**
+ A bool specifying whether the view should be loaded from a custom nib.
+
+ @see PFSignUpView
+ */
+@property (nonatomic, assign) BOOL useCustomNib;
+
 ///--------------------------------------
 /// @name Configuring Sign Up Behaviors
 ///--------------------------------------

--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
@@ -104,9 +104,14 @@ NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"additional";
 #pragma mark UIViewController
 
 - (void)loadView {
-    _signUpView = [[PFSignUpView alloc] initWithFields:_fields];
+    if(self.useCustomNib) {
+        [super loadView];
+        _signUpView = self.view;
+    } else {
+        _signUpView = [[PFSignUpView alloc] initWithFields:_fields];
+        self.view = _signUpView;
+    }
     _signUpView.presentingViewController = self;
-    self.view = _signUpView;
 }
 
 - (void)viewDidLoad {

--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
@@ -106,7 +106,7 @@ NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"additional";
 - (void)loadView {
     if(self.useCustomNib) {
         [super loadView];
-        _signUpView = self.view;
+        _signUpView = (PFSignUpView *) self.view;
     } else {
         _signUpView = [[PFSignUpView alloc] initWithFields:_fields];
         self.view = _signUpView;


### PR DESCRIPTION
Tweak `PFLogInView`, `PFLogInViewController`, `PFSignUpView`, `PFSignUpViewController` allowing to use custom nib instead of default UI.
You may ask why allowing custom nib in `ParseUI-iOS`, don't use `ParseUI-iOS` then and use your own UI? `ParseUI-iOS` give you a UI but also a flow and logic control, I want to be able to tweak the former but still benefit from the later...

Then you can create a subclass of `PFLogInViewController` looking like this:

```
- (instancetype)init {
    self = [super initWithNibName:NSStringFromClass([self class]) bundle:nil];
    if (self) {
        self.useCustomNib = YES;
    }
    return self;
}
```

Likewise for PFSignupViewController.
