### PR TITLE
Made `signUpViewController:shouldBeginSignUp` info keys public

### DIFF
--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.h
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.h
@@ -104,6 +104,30 @@ extern NSString *const PFSignUpFailureNotification;
 extern NSString *const PFSignUpCancelNotification;
 
 ///--------------------------------------
+// @name Keys for info dictionary on `signUpViewController:shouldBeginSignUp` delegate method.
+///--------------------------------------
+
+/**
+ Username supplied during sign up.
+ */
+extern NSString *const PFSignUpViewControllerDelegateInfoUsernameKey;
+
+/**
+ Password supplied during sign up.
+ */
+extern NSString *const PFSignUpViewControllerDelegateInfoPasswordKey;
+
+/**
+ Email address supplied during sign up.
+ */
+extern NSString *const PFSignUpViewControllerDelegateInfoEmailKey;
+
+/**
+ Additional info supplied during sign up.
+ */
+extern NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey;
+
+///--------------------------------------
 /// @name PFSignUpViewControllerDelegate
 ///--------------------------------------
 

--- a/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
+++ b/ParseUI/Classes/SignUpViewController/PFSignUpViewController.m
@@ -34,10 +34,10 @@ NSString *const PFSignUpFailureNotification = @"com.parse.ui.signup.failure";
 NSString *const PFSignUpCancelNotification = @"com.parse.ui.signup.cancel";
 
 // Keys that are used to pass information to the delegate on `signUpViewController:shouldBeginSignUp`.
-static NSString *const PFSignUpViewControllerDelegateInfoUsernameKey = @"username";
-static NSString *const PFSignUpViewControllerDelegateInfoPasswordKey = @"password";
-static NSString *const PFSignUpViewControllerDelegateInfoEmailKey = @"email";
-static NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"additional";
+NSString *const PFSignUpViewControllerDelegateInfoUsernameKey = @"username";
+NSString *const PFSignUpViewControllerDelegateInfoPasswordKey = @"password";
+NSString *const PFSignUpViewControllerDelegateInfoEmailKey = @"email";
+NSString *const PFSignUpViewControllerDelegateInfoAdditionalKey = @"additional";
 
 @interface PFSignUpViewController () {
     struct {


### PR DESCRIPTION
Moved the info dictionary keys for the `signUpViewController:shouldBeginSignUp` delegate method to be public, as they were private and not usable outside `PFSignUpViewController`.